### PR TITLE
feat(parser): add Guice-aware symbol extraction and indexing

### DIFF
--- a/graphus-indexer/src/main/java/io/graphus/indexer/SymbolChunkBuilder.java
+++ b/graphus-indexer/src/main/java/io/graphus/indexer/SymbolChunkBuilder.java
@@ -5,6 +5,7 @@ import io.graphus.model.CallGraph;
 import io.graphus.model.ClassNode;
 import io.graphus.model.FieldNode;
 import io.graphus.model.MethodNode;
+import io.graphus.model.SymbolKind;
 import io.graphus.model.SymbolNode;
 import io.graphus.model.UnresolvedNode;
 import java.util.ArrayList;
@@ -48,10 +49,16 @@ public final class SymbolChunkBuilder {
                 .put("line", node.getLine());
 
         if (node instanceof ClassNode classNode) {
-            metadata = metadata.put("spring_stereotype", classNode.getSpringMetadata().getStereotype().name());
+            metadata = metadata
+                    .put("spring_stereotype", classNode.getSpringMetadata().getStereotype().name())
+                    .put("guice_stereotype", classNode.getGuiceMetadata().getStereotype().name());
         } else if (node instanceof MethodNode methodNode) {
             metadata = metadata
                     .put("spring_stereotype", methodNode.getSpringMetadata().getStereotype().name())
+                    .put("guice_stereotype", methodNode.getGuiceMetadata().getStereotype().name())
+                    .put("guice_injection", methodNode.getGuiceMetadata().getInjectionType().name())
+                    .put("guice_singleton", String.valueOf(methodNode.getGuiceMetadata().isSingleton()))
+                    .put("guice_named", methodNode.getGuiceMetadata().getNamedValue())
                     .put("callers", String.join(",", methodNode.getCallers()))
                     .put("callees", String.join(",", methodNode.getCallees()))
                     .put("signature", methodNode.getSignature());
@@ -71,13 +78,18 @@ public final class SymbolChunkBuilder {
             String mappings = methodNode.getSpringMetadata().getHttpMappings().stream()
                     .map(mapping -> mapping.method() + " " + mapping.path())
                     .collect(Collectors.joining(", "));
-            return "[METHOD] " + methodNode.getId() + "\n"
+            String kindLabel = methodNode.getKind() == SymbolKind.CONSTRUCTOR ? "CONSTRUCTOR" : "METHOD";
+            return "[" + kindLabel + "] " + methodNode.getId() + "\n"
                     + "Class: " + methodNode.getDeclaringClassId() + "\n"
                     + "Signature: " + methodNode.getSignature() + "\n"
                     + "Return: " + methodNode.getReturnType() + "\n"
                     + "Parameters: " + methodNode.getParams() + "\n"
                     + "Annotations: " + String.join(", ", methodNode.getAnnotations()) + "\n"
                     + "Spring Stereotype: " + methodNode.getSpringMetadata().getStereotype() + "\n"
+                    + "Guice Stereotype: " + methodNode.getGuiceMetadata().getStereotype() + "\n"
+                    + "Guice Injection: " + methodNode.getGuiceMetadata().getInjectionType() + "\n"
+                    + "Singleton: " + methodNode.getGuiceMetadata().isSingleton() + "\n"
+                    + "Named: " + methodNode.getGuiceMetadata().getNamedValue() + "\n"
                     + "HTTP Mappings: " + mappings + "\n"
                     + "Transactional: " + methodNode.getSpringMetadata().isTransactional() + "\n"
                     + "Callers: " + String.join(", ", methodNode.getCallers()) + "\n"
@@ -91,6 +103,7 @@ public final class SymbolChunkBuilder {
                     + "Superclass: " + classNode.getSuperClass() + "\n"
                     + "Interfaces: " + String.join(", ", classNode.getInterfaces()) + "\n"
                     + "Spring Stereotype: " + classNode.getSpringMetadata().getStereotype() + "\n"
+                    + "Guice Stereotype: " + classNode.getGuiceMetadata().getStereotype() + "\n"
                     + "Fields: " + String.join(", ", classNode.getFields()) + "\n"
                     + "Methods: " + String.join(", ", classNode.getMethods()) + "\n"
                     + "Outgoing Symbols: " + String.join(", ", callGraph.outgoingNeighbors(classNode.getId())) + "\n"
@@ -102,6 +115,7 @@ public final class SymbolChunkBuilder {
                     + "Name: " + fieldNode.getName() + "\n"
                     + "Type: " + fieldNode.getType() + "\n"
                     + "Annotations: " + String.join(", ", fieldNode.getAnnotations()) + "\n"
+                    + "Guice Injection: " + fieldNode.getGuiceMetadata().getInjectionType() + "\n"
                     + "File: " + fieldNode.getFilePath() + ":" + fieldNode.getLine();
         }
         if (node instanceof UnresolvedNode unresolvedNode) {

--- a/graphus-model/src/main/java/io/graphus/model/ClassNode.java
+++ b/graphus-model/src/main/java/io/graphus/model/ClassNode.java
@@ -13,6 +13,7 @@ public final class ClassNode extends SymbolNode {
     private final List<String> fields = new ArrayList<>();
     private final List<String> methods = new ArrayList<>();
     private final SpringMetadata springMetadata;
+    private final GuiceMetadata guiceMetadata;
 
     public ClassNode(
             String id,
@@ -22,7 +23,8 @@ public final class ClassNode extends SymbolNode {
             List<String> annotations,
             String superClass,
             List<String> interfaces,
-            SpringMetadata springMetadata
+            SpringMetadata springMetadata,
+            GuiceMetadata guiceMetadata
     ) {
         super(id, SymbolKind.CLASS, filePath, line);
         this.simpleName = simpleName;
@@ -30,6 +32,7 @@ public final class ClassNode extends SymbolNode {
         this.superClass = superClass == null ? "" : superClass;
         this.interfaces = interfaces == null ? List.of() : List.copyOf(interfaces);
         this.springMetadata = springMetadata == null ? new SpringMetadata() : springMetadata;
+        this.guiceMetadata = guiceMetadata == null ? new GuiceMetadata() : guiceMetadata;
     }
 
     public String getSimpleName() {
@@ -66,5 +69,9 @@ public final class ClassNode extends SymbolNode {
 
     public SpringMetadata getSpringMetadata() {
         return springMetadata;
+    }
+
+    public GuiceMetadata getGuiceMetadata() {
+        return guiceMetadata;
     }
 }

--- a/graphus-model/src/main/java/io/graphus/model/FieldNode.java
+++ b/graphus-model/src/main/java/io/graphus/model/FieldNode.java
@@ -9,6 +9,7 @@ public final class FieldNode extends SymbolNode {
     private final String type;
     private final List<String> annotations;
     private final SpringMetadata springMetadata;
+    private final GuiceMetadata guiceMetadata;
 
     public FieldNode(
             String id,
@@ -18,7 +19,8 @@ public final class FieldNode extends SymbolNode {
             String filePath,
             int line,
             List<String> annotations,
-            SpringMetadata springMetadata
+            SpringMetadata springMetadata,
+            GuiceMetadata guiceMetadata
     ) {
         super(id, SymbolKind.FIELD, filePath, line);
         this.declaringClassId = declaringClassId;
@@ -26,6 +28,7 @@ public final class FieldNode extends SymbolNode {
         this.type = type;
         this.annotations = annotations == null ? List.of() : List.copyOf(annotations);
         this.springMetadata = springMetadata == null ? new SpringMetadata() : springMetadata;
+        this.guiceMetadata = guiceMetadata == null ? new GuiceMetadata() : guiceMetadata;
     }
 
     public String getDeclaringClassId() {
@@ -46,5 +49,9 @@ public final class FieldNode extends SymbolNode {
 
     public SpringMetadata getSpringMetadata() {
         return springMetadata;
+    }
+
+    public GuiceMetadata getGuiceMetadata() {
+        return guiceMetadata;
     }
 }

--- a/graphus-model/src/main/java/io/graphus/model/GuiceMetadata.java
+++ b/graphus-model/src/main/java/io/graphus/model/GuiceMetadata.java
@@ -1,0 +1,59 @@
+package io.graphus.model;
+
+public final class GuiceMetadata {
+
+    private GuiceStereotype stereotype = GuiceStereotype.NONE;
+    private InjectionType injectionType = InjectionType.NONE;
+    private boolean singleton;
+    private boolean requestScoped;
+    private boolean sessionScoped;
+    private String namedValue = "";
+
+    public GuiceStereotype getStereotype() {
+        return stereotype;
+    }
+
+    public void setStereotype(GuiceStereotype stereotype) {
+        this.stereotype = stereotype == null ? GuiceStereotype.NONE : stereotype;
+    }
+
+    public InjectionType getInjectionType() {
+        return injectionType;
+    }
+
+    public void setInjectionType(InjectionType injectionType) {
+        this.injectionType = injectionType == null ? InjectionType.NONE : injectionType;
+    }
+
+    public boolean isSingleton() {
+        return singleton;
+    }
+
+    public void setSingleton(boolean singleton) {
+        this.singleton = singleton;
+    }
+
+    public boolean isRequestScoped() {
+        return requestScoped;
+    }
+
+    public void setRequestScoped(boolean requestScoped) {
+        this.requestScoped = requestScoped;
+    }
+
+    public boolean isSessionScoped() {
+        return sessionScoped;
+    }
+
+    public void setSessionScoped(boolean sessionScoped) {
+        this.sessionScoped = sessionScoped;
+    }
+
+    public String getNamedValue() {
+        return namedValue;
+    }
+
+    public void setNamedValue(String namedValue) {
+        this.namedValue = namedValue == null ? "" : namedValue;
+    }
+}

--- a/graphus-model/src/main/java/io/graphus/model/GuiceStereotype.java
+++ b/graphus-model/src/main/java/io/graphus/model/GuiceStereotype.java
@@ -1,0 +1,7 @@
+package io.graphus.model;
+
+public enum GuiceStereotype {
+    MODULE,
+    PROVIDES,
+    NONE
+}

--- a/graphus-model/src/main/java/io/graphus/model/MethodNode.java
+++ b/graphus-model/src/main/java/io/graphus/model/MethodNode.java
@@ -16,6 +16,7 @@ public final class MethodNode extends SymbolNode {
     private final Set<String> callers = new LinkedHashSet<>();
     private final Set<String> callees = new LinkedHashSet<>();
     private final SpringMetadata springMetadata;
+    private final GuiceMetadata guiceMetadata;
 
     public MethodNode(
             String id,
@@ -30,7 +31,39 @@ public final class MethodNode extends SymbolNode {
             int line,
             SpringMetadata springMetadata
     ) {
-        super(id, SymbolKind.METHOD, filePath, line);
+        this(
+                id,
+                SymbolKind.METHOD,
+                declaringClassId,
+                name,
+                signature,
+                returnType,
+                params,
+                modifiers,
+                annotations,
+                filePath,
+                line,
+                springMetadata,
+                null
+        );
+    }
+
+    public MethodNode(
+            String id,
+            SymbolKind kind,
+            String declaringClassId,
+            String name,
+            String signature,
+            String returnType,
+            List<MethodParam> params,
+            List<String> modifiers,
+            List<String> annotations,
+            String filePath,
+            int line,
+            SpringMetadata springMetadata,
+            GuiceMetadata guiceMetadata
+    ) {
+        super(id, kind == null ? SymbolKind.METHOD : kind, filePath, line);
         this.declaringClassId = declaringClassId;
         this.name = name;
         this.signature = signature;
@@ -39,6 +72,7 @@ public final class MethodNode extends SymbolNode {
         this.modifiers = modifiers == null ? List.of() : List.copyOf(modifiers);
         this.annotations = annotations == null ? List.of() : List.copyOf(annotations);
         this.springMetadata = springMetadata == null ? new SpringMetadata() : springMetadata;
+        this.guiceMetadata = guiceMetadata == null ? new GuiceMetadata() : guiceMetadata;
     }
 
     public String getDeclaringClassId() {
@@ -91,5 +125,9 @@ public final class MethodNode extends SymbolNode {
 
     public SpringMetadata getSpringMetadata() {
         return springMetadata;
+    }
+
+    public GuiceMetadata getGuiceMetadata() {
+        return guiceMetadata;
     }
 }

--- a/graphus-model/src/main/java/io/graphus/model/SymbolKind.java
+++ b/graphus-model/src/main/java/io/graphus/model/SymbolKind.java
@@ -3,6 +3,7 @@ package io.graphus.model;
 public enum SymbolKind {
     CLASS,
     METHOD,
+    CONSTRUCTOR,
     FIELD,
     ANNOTATION,
     UNRESOLVED

--- a/graphus-parser/src/main/java/io/graphus/parser/CallGraphBuilder.java
+++ b/graphus-parser/src/main/java/io/graphus/parser/CallGraphBuilder.java
@@ -1,6 +1,6 @@
 package io.graphus.parser;
 
-import com.github.javaparser.ast.body.MethodDeclaration;
+import com.github.javaparser.ast.body.CallableDeclaration;
 import com.github.javaparser.ast.expr.MethodCallExpr;
 import com.github.javaparser.resolution.UnsolvedSymbolException;
 import io.graphus.model.CallGraph;
@@ -17,14 +17,14 @@ public final class CallGraphBuilder {
         this.repositoryRoot = repositoryRoot;
     }
 
-    public int buildEdges(CallGraph callGraph, Map<MethodDeclaration, String> methodIdsByDeclaration) {
+    public int buildEdges(CallGraph callGraph, Map<CallableDeclaration<?>, String> callableIdsByDeclaration) {
         AtomicInteger unresolvedCalls = new AtomicInteger();
 
-        for (Map.Entry<MethodDeclaration, String> entry : methodIdsByDeclaration.entrySet()) {
-            MethodDeclaration methodDeclaration = entry.getKey();
+        for (Map.Entry<CallableDeclaration<?>, String> entry : callableIdsByDeclaration.entrySet()) {
+            CallableDeclaration<?> declaration = entry.getKey();
             String callerId = entry.getValue();
 
-            for (MethodCallExpr methodCallExpr : methodDeclaration.findAll(MethodCallExpr.class)) {
+            for (MethodCallExpr methodCallExpr : declaration.findAll(MethodCallExpr.class)) {
                 try {
                     String calleeId = SymbolIdResolver.methodId(methodCallExpr);
                     callGraph.addEdge(callerId, calleeId);

--- a/graphus-parser/src/main/java/io/graphus/parser/GuiceAnnotationExtractor.java
+++ b/graphus-parser/src/main/java/io/graphus/parser/GuiceAnnotationExtractor.java
@@ -1,0 +1,75 @@
+package io.graphus.parser;
+
+import com.github.javaparser.ast.NodeList;
+import com.github.javaparser.ast.body.ClassOrInterfaceDeclaration;
+import com.github.javaparser.ast.body.ConstructorDeclaration;
+import com.github.javaparser.ast.body.FieldDeclaration;
+import com.github.javaparser.ast.body.MethodDeclaration;
+import com.github.javaparser.ast.expr.AnnotationExpr;
+import io.graphus.model.GuiceMetadata;
+import io.graphus.model.GuiceStereotype;
+import io.graphus.model.InjectionType;
+import java.util.Optional;
+
+public final class GuiceAnnotationExtractor {
+
+    public GuiceMetadata extractForClass(ClassOrInterfaceDeclaration declaration) {
+        GuiceMetadata metadata = extract(declaration.getAnnotations(), InjectionType.NONE);
+        boolean isModuleType = declaration.getExtendedTypes().stream()
+                .map(type -> type.getNameAsString())
+                .anyMatch(name -> name.equals("AbstractModule") || name.equals("PrivateModule"));
+        if (isModuleType) {
+            metadata.setStereotype(GuiceStereotype.MODULE);
+        }
+        return metadata;
+    }
+
+    public GuiceMetadata extractForMethod(MethodDeclaration declaration) {
+        return extract(declaration.getAnnotations(), InjectionType.METHOD);
+    }
+
+    public GuiceMetadata extractForField(FieldDeclaration declaration) {
+        return extract(declaration.getAnnotations(), InjectionType.FIELD);
+    }
+
+    public GuiceMetadata extractForConstructor(ConstructorDeclaration declaration) {
+        return extract(declaration.getAnnotations(), InjectionType.CONSTRUCTOR);
+    }
+
+    private GuiceMetadata extract(NodeList<AnnotationExpr> annotations, InjectionType injectTarget) {
+        GuiceMetadata metadata = new GuiceMetadata();
+        for (AnnotationExpr annotation : annotations) {
+            String simpleName = annotation.getName().getIdentifier();
+            switch (simpleName) {
+                case "Inject" -> metadata.setInjectionType(injectTarget);
+                case "Provides" -> metadata.setStereotype(GuiceStereotype.PROVIDES);
+                case "Singleton" -> metadata.setSingleton(true);
+                case "RequestScoped" -> metadata.setRequestScoped(true);
+                case "SessionScoped" -> metadata.setSessionScoped(true);
+                case "Named" -> extractNamedValue(annotation).ifPresent(metadata::setNamedValue);
+                default -> {
+                    // non-Guice annotation
+                }
+            }
+        }
+        return metadata;
+    }
+
+    private Optional<String> extractNamedValue(AnnotationExpr annotationExpr) {
+        if (annotationExpr.isSingleMemberAnnotationExpr()) {
+            return Optional.of(annotationExpr.asSingleMemberAnnotationExpr()
+                    .getMemberValue()
+                    .toString()
+                    .replace("\"", ""));
+        }
+        if (annotationExpr.isNormalAnnotationExpr()) {
+            return annotationExpr.asNormalAnnotationExpr()
+                    .getPairs()
+                    .stream()
+                    .filter(pair -> pair.getName().getIdentifier().equals("value"))
+                    .findFirst()
+                    .map(pair -> pair.getValue().toString().replace("\"", ""));
+        }
+        return Optional.empty();
+    }
+}

--- a/graphus-parser/src/main/java/io/graphus/parser/ParserContext.java
+++ b/graphus-parser/src/main/java/io/graphus/parser/ParserContext.java
@@ -1,6 +1,7 @@
 package io.graphus.parser;
 
 import com.github.javaparser.ast.body.MethodDeclaration;
+import com.github.javaparser.ast.body.CallableDeclaration;
 import io.graphus.model.CallGraph;
 import java.util.LinkedHashMap;
 import java.util.Map;
@@ -8,7 +9,7 @@ import java.util.Map;
 final class ParserContext {
 
     private final CallGraph callGraph;
-    private final Map<MethodDeclaration, String> methodIdsByDeclaration = new LinkedHashMap<>();
+    private final Map<CallableDeclaration<?>, String> callableIdsByDeclaration = new LinkedHashMap<>();
 
     ParserContext(CallGraph callGraph) {
         this.callGraph = callGraph;
@@ -19,10 +20,14 @@ final class ParserContext {
     }
 
     void registerMethod(MethodDeclaration declaration, String methodId) {
-        methodIdsByDeclaration.put(declaration, methodId);
+        registerCallable(declaration, methodId);
     }
 
-    Map<MethodDeclaration, String> methodIdsByDeclaration() {
-        return methodIdsByDeclaration;
+    void registerCallable(CallableDeclaration<?> declaration, String callableId) {
+        callableIdsByDeclaration.put(declaration, callableId);
+    }
+
+    Map<CallableDeclaration<?>, String> callableIdsByDeclaration() {
+        return callableIdsByDeclaration;
     }
 }

--- a/graphus-parser/src/main/java/io/graphus/parser/ProjectParser.java
+++ b/graphus-parser/src/main/java/io/graphus/parser/ProjectParser.java
@@ -19,6 +19,7 @@ import java.util.stream.Stream;
 public final class ProjectParser {
 
     private final SpringAnnotationExtractor springAnnotationExtractor = new SpringAnnotationExtractor();
+    private final GuiceAnnotationExtractor guiceAnnotationExtractor = new GuiceAnnotationExtractor();
 
     public ProjectParserResult parse(Path repositoryRoot, List<Path> sourceRoots) throws IOException {
         return parse(repositoryRoot, sourceRoots, (file, current, total) -> {});
@@ -32,7 +33,11 @@ public final class ProjectParser {
 
         CallGraph callGraph = new CallGraph();
         ParserContext parserContext = new ParserContext(callGraph);
-        SymbolVisitor symbolVisitor = new SymbolVisitor(springAnnotationExtractor, repositoryRoot.toAbsolutePath().normalize());
+        SymbolVisitor symbolVisitor = new SymbolVisitor(
+                springAnnotationExtractor,
+                guiceAnnotationExtractor,
+                repositoryRoot.toAbsolutePath().normalize()
+        );
 
         List<Path> allJavaFiles = new ArrayList<>();
         for (Path sourceRoot : normalizedSourceRoots) {
@@ -51,7 +56,7 @@ public final class ProjectParser {
         }
 
         CallGraphBuilder callGraphBuilder = new CallGraphBuilder(repositoryRoot.toAbsolutePath().normalize());
-        int unresolvedCalls = callGraphBuilder.buildEdges(callGraph, parserContext.methodIdsByDeclaration());
+        int unresolvedCalls = callGraphBuilder.buildEdges(callGraph, parserContext.callableIdsByDeclaration());
         return new ProjectParserResult(callGraph, parsedFiles, unresolvedCalls);
     }
 

--- a/graphus-parser/src/main/java/io/graphus/parser/SymbolIdResolver.java
+++ b/graphus-parser/src/main/java/io/graphus/parser/SymbolIdResolver.java
@@ -2,10 +2,12 @@ package io.graphus.parser;
 
 import com.github.javaparser.ast.Node;
 import com.github.javaparser.ast.body.ClassOrInterfaceDeclaration;
+import com.github.javaparser.ast.body.ConstructorDeclaration;
 import com.github.javaparser.ast.body.MethodDeclaration;
 import com.github.javaparser.ast.expr.MethodCallExpr;
 import com.github.javaparser.resolution.declarations.ResolvedMethodDeclaration;
 import java.nio.file.Path;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 final class SymbolIdResolver {
@@ -27,12 +29,20 @@ final class SymbolIdResolver {
         try {
             return declaration.resolve().getQualifiedSignature();
         } catch (RuntimeException ignored) {
-            return declaration.findAncestor(ClassOrInterfaceDeclaration.class)
+            return enclosingClass(declaration)
                     .map(SymbolIdResolver::classId)
                     .orElse("unknown-class")
                     + "#"
                     + signature(declaration);
         }
+    }
+
+    static String constructorId(ConstructorDeclaration declaration) {
+        return enclosingClass(declaration)
+                .map(SymbolIdResolver::classId)
+                .orElse("unknown-class")
+                + "#"
+                + signature(declaration);
     }
 
     static String methodId(ResolvedMethodDeclaration declaration) {
@@ -50,6 +60,13 @@ final class SymbolIdResolver {
         return declaration.getNameAsString() + "(" + params + ")";
     }
 
+    static String signature(ConstructorDeclaration declaration) {
+        String params = declaration.getParameters().stream()
+                .map(parameter -> parameter.getType().asString())
+                .collect(Collectors.joining(", "));
+        return declaration.getNameAsString() + "(" + params + ")";
+    }
+
     static String filePath(Node node, Path repositoryRoot) {
         return node.findCompilationUnit()
                 .flatMap(compilationUnit -> compilationUnit.getStorage().map(storage -> {
@@ -60,5 +77,16 @@ final class SymbolIdResolver {
                     return absolutePath.toString();
                 }))
                 .orElse("");
+    }
+
+    private static Optional<ClassOrInterfaceDeclaration> enclosingClass(Node node) {
+        Node current = node;
+        while (current.getParentNode().isPresent()) {
+            current = current.getParentNode().orElseThrow();
+            if (current instanceof ClassOrInterfaceDeclaration declaration) {
+                return Optional.of(declaration);
+            }
+        }
+        return Optional.empty();
     }
 }

--- a/graphus-parser/src/main/java/io/graphus/parser/SymbolVisitor.java
+++ b/graphus-parser/src/main/java/io/graphus/parser/SymbolVisitor.java
@@ -1,27 +1,38 @@
 package io.graphus.parser;
 
 import com.github.javaparser.ast.body.ClassOrInterfaceDeclaration;
+import com.github.javaparser.ast.body.ConstructorDeclaration;
 import com.github.javaparser.ast.body.FieldDeclaration;
 import com.github.javaparser.ast.body.MethodDeclaration;
 import com.github.javaparser.ast.body.VariableDeclarator;
 import com.github.javaparser.ast.visitor.VoidVisitorAdapter;
+import com.github.javaparser.ast.Node;
 import io.graphus.model.ClassNode;
 import io.graphus.model.FieldNode;
+import io.graphus.model.GuiceMetadata;
 import io.graphus.model.MethodNode;
 import io.graphus.model.MethodParam;
 import io.graphus.model.SpringMetadata;
+import io.graphus.model.SymbolKind;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 public final class SymbolVisitor extends VoidVisitorAdapter<ParserContext> {
 
     private final SpringAnnotationExtractor springAnnotationExtractor;
+    private final GuiceAnnotationExtractor guiceAnnotationExtractor;
     private final Path repositoryRoot;
 
-    public SymbolVisitor(SpringAnnotationExtractor springAnnotationExtractor, Path repositoryRoot) {
+    public SymbolVisitor(
+            SpringAnnotationExtractor springAnnotationExtractor,
+            GuiceAnnotationExtractor guiceAnnotationExtractor,
+            Path repositoryRoot
+    ) {
         this.springAnnotationExtractor = springAnnotationExtractor;
+        this.guiceAnnotationExtractor = guiceAnnotationExtractor;
         this.repositoryRoot = repositoryRoot;
     }
 
@@ -43,6 +54,7 @@ public final class SymbolVisitor extends VoidVisitorAdapter<ParserContext> {
                 .map(type -> type.getNameAsString())
                 .toList();
         SpringMetadata springMetadata = springAnnotationExtractor.extract(declaration.getAnnotations());
+        GuiceMetadata guiceMetadata = guiceAnnotationExtractor.extractForClass(declaration);
 
         ClassNode classNode = new ClassNode(
                 classId,
@@ -52,7 +64,8 @@ public final class SymbolVisitor extends VoidVisitorAdapter<ParserContext> {
                 annotations,
                 superClass,
                 interfaces,
-                springMetadata
+                springMetadata,
+                guiceMetadata
         );
         context.callGraph().addNode(classNode);
     }
@@ -61,7 +74,7 @@ public final class SymbolVisitor extends VoidVisitorAdapter<ParserContext> {
     public void visit(FieldDeclaration declaration, ParserContext context) {
         super.visit(declaration, context);
 
-        String classId = declaration.findAncestor(ClassOrInterfaceDeclaration.class)
+        String classId = enclosingClass(declaration)
                 .map(SymbolIdResolver::classId)
                 .orElse("unknown-class");
         String filePath = SymbolIdResolver.filePath(declaration, repositoryRoot);
@@ -70,6 +83,7 @@ public final class SymbolVisitor extends VoidVisitorAdapter<ParserContext> {
                 .map(annotation -> "@" + annotation.getName().asString())
                 .toList();
         SpringMetadata springMetadata = springAnnotationExtractor.extract(declaration.getAnnotations());
+        GuiceMetadata guiceMetadata = guiceAnnotationExtractor.extractForField(declaration);
 
         for (VariableDeclarator variable : declaration.getVariables()) {
             String fieldId = classId + "#" + variable.getNameAsString();
@@ -81,7 +95,8 @@ public final class SymbolVisitor extends VoidVisitorAdapter<ParserContext> {
                     filePath,
                     line,
                     annotations,
-                    springMetadata
+                    springMetadata,
+                    guiceMetadata
             );
             context.callGraph().addNode(fieldNode);
             if (context.callGraph().getNode(classId) instanceof ClassNode classNode) {
@@ -94,7 +109,7 @@ public final class SymbolVisitor extends VoidVisitorAdapter<ParserContext> {
     public void visit(MethodDeclaration declaration, ParserContext context) {
         super.visit(declaration, context);
 
-        String classId = declaration.findAncestor(ClassOrInterfaceDeclaration.class)
+        String classId = enclosingClass(declaration)
                 .map(SymbolIdResolver::classId)
                 .orElse("unknown-class");
         String methodId = SymbolIdResolver.methodId(declaration);
@@ -111,9 +126,11 @@ public final class SymbolVisitor extends VoidVisitorAdapter<ParserContext> {
                 .map(annotation -> "@" + annotation.getName().asString())
                 .collect(Collectors.toCollection(ArrayList::new));
         SpringMetadata springMetadata = springAnnotationExtractor.extractForMethod(declaration);
+        GuiceMetadata guiceMetadata = guiceAnnotationExtractor.extractForMethod(declaration);
 
         MethodNode methodNode = new MethodNode(
                 methodId,
+                SymbolKind.METHOD,
                 classId,
                 declaration.getNameAsString(),
                 SymbolIdResolver.signature(declaration),
@@ -123,13 +140,71 @@ public final class SymbolVisitor extends VoidVisitorAdapter<ParserContext> {
                 annotations,
                 filePath,
                 line,
-                springMetadata
+                springMetadata,
+                guiceMetadata
         );
         context.callGraph().addNode(methodNode);
-        context.registerMethod(declaration, methodId);
+        context.registerCallable(declaration, methodId);
 
         if (context.callGraph().getNode(classId) instanceof ClassNode classNode) {
             classNode.addMethod(methodId);
         }
+    }
+
+    @Override
+    public void visit(ConstructorDeclaration declaration, ParserContext context) {
+        super.visit(declaration, context);
+
+        String classId = enclosingClass(declaration)
+                .map(SymbolIdResolver::classId)
+                .orElse("unknown-class");
+        String constructorId = SymbolIdResolver.constructorId(declaration);
+        String filePath = SymbolIdResolver.filePath(declaration, repositoryRoot);
+        int line = declaration.getBegin().map(position -> position.line).orElse(-1);
+
+        List<MethodParam> params = declaration.getParameters().stream()
+                .map(parameter -> new MethodParam(parameter.getNameAsString(), parameter.getTypeAsString()))
+                .toList();
+        List<String> modifiers = declaration.getModifiers().stream()
+                .map(modifier -> modifier.getKeyword().asString())
+                .toList();
+        List<String> annotations = declaration.getAnnotations().stream()
+                .map(annotation -> "@" + annotation.getName().asString())
+                .collect(Collectors.toCollection(ArrayList::new));
+        SpringMetadata springMetadata = springAnnotationExtractor.extract(declaration.getAnnotations());
+        GuiceMetadata guiceMetadata = guiceAnnotationExtractor.extractForConstructor(declaration);
+
+        MethodNode constructorNode = new MethodNode(
+                constructorId,
+                SymbolKind.CONSTRUCTOR,
+                classId,
+                declaration.getNameAsString(),
+                SymbolIdResolver.signature(declaration),
+                declaration.getNameAsString(),
+                params,
+                modifiers,
+                annotations,
+                filePath,
+                line,
+                springMetadata,
+                guiceMetadata
+        );
+        context.callGraph().addNode(constructorNode);
+        context.registerCallable(declaration, constructorId);
+
+        if (context.callGraph().getNode(classId) instanceof ClassNode classNode) {
+            classNode.addMethod(constructorId);
+        }
+    }
+
+    private Optional<ClassOrInterfaceDeclaration> enclosingClass(Node node) {
+        Node current = node;
+        while (current.getParentNode().isPresent()) {
+            current = current.getParentNode().orElseThrow();
+            if (current instanceof ClassOrInterfaceDeclaration declaration) {
+                return Optional.of(declaration);
+            }
+        }
+        return Optional.empty();
     }
 }


### PR DESCRIPTION
graphus-model/SymbolKind: add CONSTRUCTOR to represent constructor symbols in the graph.
graphus-model/GuiceStereotype+GuiceMetadata: introduce structured Guice metadata model.
graphus-model/ClassNode,FieldNode,MethodNode: persist Guice metadata alongside Spring metadata.
graphus-parser/GuiceAnnotationExtractor: extract Guice annotations for class, method, field, and constructor contexts.
graphus-parser/SymbolVisitor+ProjectParser: wire Guice extraction and emit constructor nodes as callables.
graphus-parser/ParserContext+CallGraphBuilder+SymbolIdResolver: generalize callable tracking and constructor identifiers.
graphus-indexer/SymbolChunkBuilder: expose Guice metadata keys and constructor-aware chunk labels.