### PR TITLE
feat(cli): default --collection to directory name when omitted

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ Clears the Chroma collection, re-parses all source files, and re-indexes all sym
 graphus index \
   --repo /path/to/repo \
   --source src/main/java \
-  --collection my-repo \
+  --collection my-repo \ # optional
   --chroma-url http://localhost:8000 \
   --embedding local
 ```
@@ -88,7 +88,7 @@ graphus index \
 | ------------------ | ----------------------- | ------------------------------------------ |
 | `--repo`           | `.`                     | Repository root path                       |
 | `--source`         | _(required)_            | Java source root; repeatable               |
-| `--collection`     | _(required)_            | Chroma collection name                     |
+| `--collection`     | _(repo directory name)_ | Chroma collection name                     |
 | `--chroma-url`     | `http://localhost:8000` | Chroma base URL                            |
 | `--chroma-timeout` | `300`                   | Chroma HTTP timeout in seconds             |
 | `--batch-size`     | `500`                   | Symbols per embedding/index batch          |
@@ -103,10 +103,21 @@ Re-indexes only files that were added, modified, or deleted since the last `inde
 graphus sync \
   --repo /path/to/repo \
   --source src/main/java \
-  --collection my-repo
+  --collection my-repo # optional
 ```
 
 Accepts the same options as `index`. Exits with an error if no checksum registry is found.
+
+| Option             | Default                 | Description                                |
+| ------------------ | ----------------------- | ------------------------------------------ |
+| `--repo`           | `.`                     | Repository root path                       |
+| `--source`         | _(required)_            | Java source root; repeatable               |
+| `--collection`     | _(repo directory name)_ | Chroma collection name                     |
+| `--chroma-url`     | `http://localhost:8000` | Chroma base URL                            |
+| `--chroma-timeout` | `300`                   | Chroma HTTP timeout in seconds             |
+| `--batch-size`     | `500`                   | Symbols per embedding/index batch          |
+| `--embedding`      | `local`                 | Embedding backend: `local` or `openai`     |
+| `--state-dir`      | `{repo}/.graphus`       | Directory where `checksums.json` is stored |
 
 ### Homebrew release automation
 
@@ -127,17 +138,17 @@ Required GitHub configuration:
 ```bash
 graphus query \
   "POST endpoint that creates a user" \
-  --collection my-repo \
+  --collection my-repo \ # optional
   --chroma-url http://localhost:8000 \
   --top-k 10
 ```
 
-| Option         | Default                 | Description                 |
-| -------------- | ----------------------- | --------------------------- |
-| `--collection` | _(required)_            | Chroma collection name      |
-| `--chroma-url` | `http://localhost:8000` | Chroma base URL             |
-| `--embedding`  | `local`                 | Embedding backend           |
-| `--top-k`      | `10`                    | Number of results to return |
+| Option         | Default                    | Description                 |
+| -------------- | -------------------------- | --------------------------- |
+| `--collection` | _(current directory name)_ | Chroma collection name      |
+| `--chroma-url` | `http://localhost:8000`    | Chroma base URL             |
+| `--embedding`  | `local`                    | Embedding backend           |
+| `--top-k`      | `10`                       | Number of results to return |
 
 ### Blast Radius (Callers)
 
@@ -179,7 +190,7 @@ graphus install \
 
 ```bash
 export OPENAI_API_KEY=your_key
-graphus query "where is user creation logic" --collection my-repo --embedding openai
+graphus query "where is user creation logic" --collection my-repo --embedding openai  # --collection optional
 ```
 
 > Keep the same embedding backend across `index`, `sync`, and `query` for a given collection.

--- a/graphus-cli/src/main/java/io/graphus/cli/GraphusCommand.java
+++ b/graphus-cli/src/main/java/io/graphus/cli/GraphusCommand.java
@@ -11,6 +11,7 @@ import io.graphus.model.CallGraph;
 import io.graphus.parser.ProjectParser;
 import io.graphus.parser.ProjectParserResult;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
@@ -56,7 +57,7 @@ public final class GraphusCommand implements Callable<Integer> {
         @Option(names = "--source", description = "Java source root; can be passed multiple times")
         private List<Path> sourceRoots = new ArrayList<>();
 
-        @Option(names = "--collection", required = true, description = "Chroma collection name")
+        @Option(names = "--collection", description = "Chroma collection name (default: top-level directory name of --repo)")
         private String collectionName;
 
         @Option(names = "--chroma-url", defaultValue = "http://localhost:8000", description = "Chroma base URL")
@@ -78,13 +79,16 @@ public final class GraphusCommand implements Callable<Integer> {
         public Integer call() throws Exception {
             long totalStartNanos = System.nanoTime();
             Path repoRoot = repositoryRoot.toAbsolutePath().normalize();
+            String resolvedCollectionName = (collectionName != null && !collectionName.isBlank())
+                    ? collectionName
+                    : repoRoot.getFileName().toString();
             Path resolvedStateDir = stateDir != null ? stateDir : repoRoot.resolve(".graphus");
             List<Path> normalizedSourceRoots = ProjectParser.resolveSourceRoots(repoRoot, sourceRoots);
 
             var embeddingModel = new EmbeddingModelFactory().create(parseEmbeddingBackend(embeddingBackend));
             var embeddingStore = GraphIndexer.chromaStore(
                     chromaUrl,
-                    collectionName,
+                    resolvedCollectionName,
                     Duration.ofSeconds(Math.max(1, chromaTimeoutSeconds))
             );
             GraphIndexer graphIndexer = new GraphIndexer(embeddingModel, embeddingStore, Math.max(1, batchSize));
@@ -131,7 +135,7 @@ public final class GraphusCommand implements Callable<Integer> {
         @Option(names = "--source", description = "Java source root; can be passed multiple times")
         private List<Path> sourceRoots = new ArrayList<>();
 
-        @Option(names = "--collection", required = true, description = "Chroma collection name")
+        @Option(names = "--collection", description = "Chroma collection name (default: top-level directory name of --repo)")
         private String collectionName;
 
         @Option(names = "--chroma-url", defaultValue = "http://localhost:8000", description = "Chroma base URL")
@@ -153,6 +157,9 @@ public final class GraphusCommand implements Callable<Integer> {
         public Integer call() throws Exception {
             long totalStartNanos = System.nanoTime();
             Path repoRoot = repositoryRoot.toAbsolutePath().normalize();
+            String resolvedCollectionName = (collectionName != null && !collectionName.isBlank())
+                    ? collectionName
+                    : repoRoot.getFileName().toString();
             Path resolvedStateDir = stateDir != null ? stateDir : repoRoot.resolve(".graphus");
             List<Path> normalizedSourceRoots = ProjectParser.resolveSourceRoots(repoRoot, sourceRoots);
 
@@ -185,7 +192,7 @@ public final class GraphusCommand implements Callable<Integer> {
             var embeddingModel = new EmbeddingModelFactory().create(parseEmbeddingBackend(embeddingBackend));
             var embeddingStore = GraphIndexer.chromaStore(
                     chromaUrl,
-                    collectionName,
+                    resolvedCollectionName,
                     Duration.ofSeconds(Math.max(1, chromaTimeoutSeconds))
             );
             GraphIndexer graphIndexer = new GraphIndexer(embeddingModel, embeddingStore, Math.max(1, batchSize));
@@ -236,7 +243,7 @@ public final class GraphusCommand implements Callable<Integer> {
         @Parameters(paramLabel = "QUESTION", description = "Natural language query")
         private String question;
 
-        @Option(names = "--collection", required = true, description = "Chroma collection name")
+        @Option(names = "--collection", description = "Chroma collection name (default: current directory name)")
         private String collectionName;
 
         @Option(names = "--chroma-url", defaultValue = "http://localhost:8000", description = "Chroma base URL")
@@ -250,8 +257,11 @@ public final class GraphusCommand implements Callable<Integer> {
 
         @Override
         public Integer call() {
+            String resolvedCollectionName = (collectionName != null && !collectionName.isBlank())
+                    ? collectionName
+                    : Paths.get("").toAbsolutePath().getFileName().toString();
             var embeddingModel = new EmbeddingModelFactory().create(parseEmbeddingBackend(embeddingBackend));
-            var embeddingStore = GraphIndexer.chromaStore(chromaUrl, collectionName);
+            var embeddingStore = GraphIndexer.chromaStore(chromaUrl, resolvedCollectionName);
             GraphIndexer graphIndexer = new GraphIndexer(embeddingModel, embeddingStore);
             List<GraphSearchHit> hits = graphIndexer.query(question, topK);
 

--- a/graphus-cli/src/main/java/io/graphus/cli/install/claudecode/ClaudeCodeAdapter.java
+++ b/graphus-cli/src/main/java/io/graphus/cli/install/claudecode/ClaudeCodeAdapter.java
@@ -85,10 +85,10 @@ public final class ClaudeCodeAdapter implements ToolAdapter {
                 Run a full Graphus index for the current repository.
 
                 Steps:
-                1. If needed, ask for the Chroma collection name.
-                2. Run:
-                   `graphus index --repo . --source src/main/java --collection <collection> --batch-size 500 --chroma-timeout 300`
-                3. Share parsed files, unresolved calls, and indexed symbols from command output.
+                1. Run:
+                   `graphus index --repo . --source src/main/java --batch-size 500 --chroma-timeout 300`
+                   `--collection` is optional and defaults to the repository directory name. Pass it explicitly only when targeting a collection with a different name.
+                2. Share parsed files, unresolved calls, and indexed symbols from command output.
                 """;
     }
 
@@ -102,10 +102,10 @@ public final class ClaudeCodeAdapter implements ToolAdapter {
 
                 Steps:
                 1. If `.graphus/checksums.json` does not exist, run `/project:graphus-index` first.
-                2. If needed, ask for the Chroma collection name.
-                3. Run:
-                   `graphus sync --repo . --source src/main/java --collection <collection> --batch-size 500 --chroma-timeout 300`
-                4. Share counts for added, modified, deleted, and indexed symbols.
+                2. Run:
+                   `graphus sync --repo . --source src/main/java --batch-size 500 --chroma-timeout 300`
+                   `--collection` is optional and defaults to the repository directory name. Pass it explicitly only when targeting a collection with a different name.
+                3. Share counts for added, modified, deleted, and indexed symbols.
                 """;
     }
 
@@ -119,10 +119,10 @@ public final class ClaudeCodeAdapter implements ToolAdapter {
 
                 Steps:
                 1. If `$ARGUMENTS` is empty, ask for the question to search.
-                2. If needed, ask for the Chroma collection name.
-                3. Run:
-                   `graphus query "$ARGUMENTS" --collection <collection> --top-k 10`
-                4. Summarize the top results and their metadata.
+                2. Run:
+                   `graphus query "$ARGUMENTS" --top-k 10`
+                   `--collection` is optional and defaults to the current directory name. Pass it explicitly only when targeting a collection with a different name.
+                3. Summarize the top results and their metadata.
                 """;
     }
 

--- a/graphus-cli/src/main/java/io/graphus/cli/install/cursor/CursorAdapter.java
+++ b/graphus-cli/src/main/java/io/graphus/cli/install/cursor/CursorAdapter.java
@@ -47,26 +47,26 @@ public final class CursorAdapter implements ToolAdapter {
                 ### Full Index
 
                 ```bash
-                graphus index --repo . --source src/main/java --collection <collection> --batch-size 500 --chroma-timeout 300
+                graphus index --repo . --source src/main/java --batch-size 500 --chroma-timeout 300
                 ```
 
-                Use when there is no previous index or when a full rebuild is requested.
+                Use when there is no previous index or when a full rebuild is requested. `--collection` is optional and defaults to the repository directory name.
 
                 ### Incremental Sync
 
                 ```bash
-                graphus sync --repo . --source src/main/java --collection <collection> --batch-size 500 --chroma-timeout 300
+                graphus sync --repo . --source src/main/java --batch-size 500 --chroma-timeout 300
                 ```
 
-                Use after code changes to update only added, modified, and deleted files.
+                Use after code changes to update only added, modified, and deleted files. `--collection` is optional and defaults to the repository directory name.
 
                 ### Query
 
                 ```bash
-                graphus query "<question>" --collection <collection> --top-k 10
+                graphus query "<question>" --top-k 10
                 ```
 
-                Use for natural language retrieval over indexed symbols.
+                Use for natural language retrieval over indexed symbols. `--collection` is optional and defaults to the current directory name.
 
                 ### Blast Radius
 
@@ -78,7 +78,7 @@ public final class CursorAdapter implements ToolAdapter {
 
                 ## Operating Guidelines
 
-                - Ask for the collection name if the user did not provide one.
+                - `--collection` defaults to the repository/current directory name and can be omitted in most cases. Pass it explicitly only when targeting a collection with a different name.
                 - If `.graphus/checksums.json` is missing, run `index` before `sync`.
                 - Keep embedding backend consistent between index/sync/query for the same collection.
                 - Surface key command output to the user instead of dumping raw logs.


### PR DESCRIPTION
## Summary

- `--collection` is now optional on `index`, `sync`, and `query` commands
- `index` and `sync` default to the top-level directory name of `--repo` (e.g. `--repo /projects/project-a` → `project-a`; omitting `--repo` uses the current directory name)
- `query` defaults to the current working directory name (no `--repo` option on this command)
- `CursorAdapter` and `ClaudeCodeAdapter` updated to remove "ask for collection name" prompts — agents now rely on the default
- `README` updated: option tables reflect the new default, sync section gains a full option table, usage examples annotated as optional

## Test plan

- [ ] `graphus index --repo /path/to/project-a` without `--collection` indexes into collection `project-a`
- [ ] `graphus sync --repo /path/to/project-a` without `--collection` syncs into collection `project-a`
- [ ] `graphus query "some question"` from `/path/to/project-a` without `--collection` queries collection `project-a`
- [ ] Passing `--collection my-name` still overrides the default on all three commands
- [ ] `graphus install --tool cursor` generates a rule with updated command examples (no `<collection>` placeholder)
- [ ] `graphus install --tool claude-code` generates command files without "ask for collection name" steps

Closes #7