### PR TITLE
fix(cli): disable CLI Maven publication tasks

### DIFF
--- a/graphus-cli/build.gradle.kts
+++ b/graphus-cli/build.gradle.kts
@@ -1,3 +1,5 @@
+import org.gradle.api.publish.maven.tasks.AbstractPublishToMaven
+
 plugins {
     id("graphus.java-conventions")
     application
@@ -34,4 +36,8 @@ tasks.named<com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar>("shadowJ
 tasks.named<JavaExec>("run") {
     // Keep CLI relative paths anchored at the Graphus repository root.
     workingDir = rootProject.projectDir
+}
+
+tasks.withType<AbstractPublishToMaven>().configureEach {
+    enabled = false
 }


### PR DESCRIPTION
## Summary
- Disable Maven publish tasks in graphus-cli to avoid duplicate unclassified JAR artifacts in the mavenJava publication.
- Keep CLI distribution through GitHub Release assets while preserving GitHub Packages publishing for library modules.

## Test plan
- [x] Run ./gradlew :graphus-cli:publishMavenJavaPublicationToMavenLocal --no-daemon and verify publish task is skipped.
- [x] Run ./gradlew :graphus-cli:publishMavenJavaPublicationToGitHubPackagesRepository --no-daemon and verify publish task is skipped.
- [ ] Run release workflow and confirm Homebrew formula update step executes after successful publish.

Closes #10