### PR TITLE
feat(workflow): automate issue lifecycle labels through plan, PR, and release

### DIFF
--- a/.cursor/rules/branch-on-plan-workflow.mdc
+++ b/.cursor/rules/branch-on-plan-workflow.mdc
@@ -8,7 +8,9 @@ alwaysApply: true
 - When starting work from a plan, create and switch to a new branch before implementation.
 - Infer whether work is feature vs bugfix from the request context.
 - Infer a concise, descriptive branch name from the task scope using lowercase and underscores.
-- Create a new GitHub issue for the planned work, store its id as github-issue-id. The issue should have a concise name inferred from the above steps and a comprehensive description
+- Create a new GitHub issue for the planned work, store its id as github-issue-id. The issue should have a concise name inferred from the above steps and a comprehensive description. Apply the appropriate label when creating the issue:
+  - `feature` / enhancement work → `--label "enhancement"`
+  - `bugfix` work → `--label "bug"`
 - Branch naming pattern must be:
   - `feature/<github-issue-id>` for new features or enhancements.
   - `bugfix/<cgithub-issue-id>` for bug fixes, regressions, or incorrect behavior.

--- a/.cursor/skills/push-and-create-pr/SKILL.md
+++ b/.cursor/skills/push-and-create-pr/SKILL.md
@@ -31,14 +31,14 @@ Use this skill only when the user explicitly asks to push or create a pull reque
 2. Extract issue number from branch name:
    - Branch naming convention: `feature/<issue-number>` or `bugfix/<issue-number>`.
    - Parse the numeric suffix after the last `/` (e.g. `feature/42` → `42`).
-   - If no issue number is found, omit the closing keyword.
+   - If no issue number is found, skip all issue-update steps below.
 3. Verify if branch has an upstream:
    - `git rev-parse --abbrev-ref --symbolic-full-name @{u}`
    - If no upstream, push with `-u`.
 4. Push branch:
    - Existing upstream: `git push`
    - No upstream: `git push -u origin HEAD`
-5. Create PR body with this template (include `Closes` line only when an issue number was found):
+5. Create PR body with this template (do NOT include a `Closes` line — issues are closed by the release workflow, not on merge):
 
 ```markdown
 ## Summary
@@ -51,13 +51,13 @@ Use this skill only when the user explicitly asks to push or create a pull reque
 - [ ] <test item 1>
 - [ ] <test item 2>
 
-Closes #<issue-number>
+Related to #<issue-number>
 ```
 
-6. Create PR with `gh`:
+6. Create PR with `gh` and capture the PR URL:
 
 ```bash
-gh pr create --title "<title>" --body "$(cat <<'EOF'
+PR_URL=$(gh pr create --title "<title>" --body "$(cat <<'EOF'
 ## Summary
 - <bullet 1>
 - <bullet 2>
@@ -66,12 +66,23 @@ gh pr create --title "<title>" --body "$(cat <<'EOF'
 - [ ] <test item 1>
 - [ ] <test item 2>
 
-Closes #<issue-number>
+Related to #<issue-number>
 EOF
-)"
+)")
+echo "$PR_URL"
 ```
 
-7. Return PR URL and short summary of what was pushed.
+7. If an issue number was found, extract the PR number from the URL (trailing integer) and update the linked issue:
+   - Add the `under-review` label: `gh issue edit <issue-number> --add-label "under-review"`
+   - Post a tracking comment:
+
+```bash
+PR_NUMBER=$(echo "$PR_URL" | grep -oE '[0-9]+$')
+gh issue edit <issue-number> --add-label "under-review"
+gh issue comment <issue-number> --body "PR #${PR_NUMBER} is open for review. Issue will be closed when the next release is published."
+```
+
+8. Return PR URL and short summary of what was pushed.
 
 ## Title Guidance
 

--- a/.github/workflows/issue-lifecycle.yml
+++ b/.github/workflows/issue-lifecycle.yml
@@ -1,0 +1,34 @@
+name: Issue Lifecycle
+
+on:
+  pull_request:
+    types: [closed]
+    branches: [main]
+
+permissions:
+  issues: write
+
+jobs:
+  pending-release:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Swap under-review → pending-release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_BODY: ${{ github.event.pull_request.body }}
+        run: |
+          ISSUE=$(echo "$PR_BODY" | grep -oP '(?<=#)\d+' | head -1)
+          if [ -z "$ISSUE" ]; then
+            echo "No linked issue found in PR body."
+            exit 0
+          fi
+          echo "Updating issue #${ISSUE}"
+          gh issue edit "$ISSUE" \
+            --remove-label "under-review" \
+            --add-label "pending-release" \
+            --repo "${{ github.repository }}"
+          gh issue comment "$ISSUE" \
+            --body "PR merged. Issue is now pending the next release." \
+            --repo "${{ github.repository }}"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,6 +7,7 @@ on:
 permissions:
   contents: write
   packages: write
+  issues: write
 
 jobs:
   publish:
@@ -74,3 +75,28 @@ jobs:
           git add Formula/graphus.rb
           git commit -m "graphus ${VERSION}"
           git push
+
+      - name: Close pending-release issues
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          TAG="${{ github.event.release.tag_name }}"
+          ISSUES=$(gh issue list \
+            --label "pending-release" \
+            --state open \
+            --json number \
+            --jq '.[].number' \
+            --repo "${{ github.repository }}")
+          if [ -z "$ISSUES" ]; then
+            echo "No pending-release issues found."
+            exit 0
+          fi
+          for NUM in $ISSUES; do
+            gh issue close "$NUM" \
+              --comment "Released in ${TAG}. Closing issue." \
+              --repo "${{ github.repository }}"
+            gh issue edit "$NUM" \
+              --remove-label "pending-release" \
+              --add-label "released" \
+              --repo "${{ github.repository }}"
+          done


### PR DESCRIPTION
## Summary

- Add label inference (`bug` / `enhancement`) when creating GitHub issues from the branch-on-plan-workflow rule
- Replace `Closes #N` with `Related to #N` in PR bodies so issues are not auto-closed on merge
- Add `under-review` label and tracking comment to the linked issue when a PR is opened
- New `issue-lifecycle.yml` workflow: on PR merged into `main`, swaps `under-review` → `pending-release` on the linked issue
- Update `publish.yml`: on `release: published`, closes all open `pending-release` issues, swaps label to `released`, and comments with the release version tag

## Test plan

- [ ] Create a new plan and confirm issue is created with `bug` or `enhancement` label
- [ ] Push a branch and open a PR — verify linked issue gets `under-review` label and tracking comment
- [ ] Merge a PR into `main` — verify `issue-lifecycle.yml` swaps label to `pending-release` and posts comment
- [ ] Publish a GitHub release — verify `publish.yml` closes issues, applies `released` label, and comments with the tag

Related to #12