### PR TITLE
fix(workflow): harden dependabot auto-close signal

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,11 +1,11 @@
-# To get started with Dependabot version updates, you'll need to specify which
-# package ecosystems to update and where the package manifests are located.
-# Please see the documentation for all configuration options:
-# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
-
 version: 2
 updates:
-  - package-ecosystem: "" # See documentation for possible values
-    directory: "/" # Location of package manifests
+  - package-ecosystem: "gradle"
+    directory: "/"
     schedule:
       interval: "weekly"
+      day: "monday"
+      time: "06:00"
+      timezone: "UTC"
+    labels:
+      - "dependencies"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ on:
     branches: [main]
 
 permissions:
-  contents: read
+  contents: write
 
 jobs:
   build:
@@ -28,3 +28,7 @@ jobs:
 
       - name: Build
         run: ./gradlew build --no-daemon
+
+      - name: Submit dependency graph
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        uses: gradle/actions/dependency-submission@v4

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -17,13 +17,19 @@ allprojects {
 }
 
 subprojects {
-    configurations.configureEach {
-        resolutionStrategy {
-            force(
-                "org.apache.logging.log4j:log4j-core:2.25.4",
-                "commons-io:commons-io:2.14.0",
-                "org.codehaus.plexus:plexus-utils:3.6.1",
-            )
+    pluginManager.withPlugin("java") {
+        dependencies {
+            constraints {
+                add("implementation", "org.apache.logging.log4j:log4j-core:2.25.4") {
+                    because("Addresses CVE-2025-68161, CVE-2026-34477, and CVE-2026-34480")
+                }
+                add("implementation", "commons-io:commons-io:2.14.0") {
+                    because("Addresses CVE-2024-47554")
+                }
+                add("implementation", "org.codehaus.plexus:plexus-utils:3.6.1") {
+                    because("Addresses CVE-2025-67030")
+                }
+            }
         }
     }
 


### PR DESCRIPTION
## Summary

- Replace force-based transitive overrides with Gradle dependency constraints and CVE rationale in the root build logic.
- Publish dependency graph metadata from CI on pushes to `main` and correct Dependabot Gradle update configuration.

## Test plan

- [x] Run `./gradlew build --no-daemon` and confirm success.
- [x] Run dependency insight checks to validate constraint-based resolution behavior.

Related to #${ISSUE_NUMBER}