### PR TITLE
fix(cli): output version when --version flag is passed

### DIFF
--- a/graphus-cli/build.gradle.kts
+++ b/graphus-cli/build.gradle.kts
@@ -33,6 +33,12 @@ tasks.named<com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar>("shadowJ
     mergeServiceFiles()
 }
 
+tasks.named<ProcessResources>("processResources") {
+    filesMatching("io/graphus/cli/version.properties") {
+        expand("version" to project.version)
+    }
+}
+
 tasks.named<JavaExec>("run") {
     // Keep CLI relative paths anchored at the Graphus repository root.
     workingDir = rootProject.projectDir

--- a/graphus-cli/src/main/java/io/graphus/cli/GraphusCommand.java
+++ b/graphus-cli/src/main/java/io/graphus/cli/GraphusCommand.java
@@ -26,6 +26,7 @@ import picocli.CommandLine.Parameters;
 @Command(
         name = "graphus",
         mixinStandardHelpOptions = true,
+        versionProvider = VersionProvider.class,
         subcommands = {
                 GraphusCommand.IndexCommand.class,
                 GraphusCommand.SyncCommand.class,

--- a/graphus-cli/src/main/java/io/graphus/cli/VersionProvider.java
+++ b/graphus-cli/src/main/java/io/graphus/cli/VersionProvider.java
@@ -1,0 +1,21 @@
+package io.graphus.cli;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Properties;
+import picocli.CommandLine.IVersionProvider;
+
+final class VersionProvider implements IVersionProvider {
+
+    @Override
+    public String[] getVersion() throws IOException {
+        Properties props = new Properties();
+        try (InputStream in = VersionProvider.class.getResourceAsStream("version.properties")) {
+            if (in == null) {
+                return new String[]{"graphus (unknown version)"};
+            }
+            props.load(in);
+        }
+        return new String[]{"graphus " + props.getProperty("version", "unknown")};
+    }
+}

--- a/graphus-cli/src/main/resources/io/graphus/cli/version.properties
+++ b/graphus-cli/src/main/resources/io/graphus/cli/version.properties
@@ -1,0 +1,1 @@
+version=${version}


### PR DESCRIPTION
## Summary

- Configure picocli to print a version value by wiring a custom `VersionProvider` into `GraphusCommand`
- Embed the CLI version into `version.properties` during `processResources` so runtime version output tracks `version.txt`

## Test plan

- [x] Build the CLI artifact with `./gradlew :graphus-cli:shadowJar`
- [x] Run `java -jar graphus-cli/build/libs/graphus.jar --version` and verify it prints `graphus 0.5.1`

Related to #28