### PR TITLE
feat(graphus): multi-module workspace detection and module-tagged indexing

### DIFF
--- a/buildSrc/src/main/kotlin/graphus.java-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/graphus.java-conventions.gradle.kts
@@ -18,6 +18,12 @@ tasks.withType<Test>().configureEach {
     useJUnitPlatform()
 }
 
+dependencies {
+    testImplementation(platform("org.junit:junit-bom:5.11.4"))
+    testImplementation("org.junit.jupiter:junit-jupiter")
+    testRuntimeOnly("org.junit.platform:junit-platform-launcher")
+}
+
 publishing {
     publications {
         create<MavenPublication>("mavenJava") {

--- a/graphus-cli/.gitignore
+++ b/graphus-cli/.gitignore
@@ -1,0 +1,2 @@
+# Local Graphus CLI index / checksum state
+.graphus/

--- a/graphus-cli/build.gradle.kts
+++ b/graphus-cli/build.gradle.kts
@@ -14,9 +14,6 @@ dependencies {
     implementation("info.picocli:picocli:4.7.7")
     annotationProcessor("info.picocli:picocli-codegen:4.7.7")
     implementation("org.slf4j:slf4j-simple:2.0.17")
-
-    testImplementation(platform("org.junit:junit-bom:5.11.4"))
-    testImplementation("org.junit.jupiter:junit-jupiter")
 }
 
 application {

--- a/graphus-cli/src/main/java/io/graphus/cli/CliWorkspaceLayouts.java
+++ b/graphus-cli/src/main/java/io/graphus/cli/CliWorkspaceLayouts.java
@@ -1,0 +1,72 @@
+package io.graphus.cli;
+
+import io.graphus.model.ModuleDescriptor;
+import io.graphus.model.WorkspaceDescriptor;
+import io.graphus.parser.ProjectParser;
+import io.graphus.parser.RepositoryLayoutDetector;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.List;
+
+/**
+ * Bridges Picocli entry points with {@link RepositoryLayoutDetector}: explicit {@code --source}
+ * roots bypass filesystem discovery; otherwise workspaces are inferred from the filesystem.
+ */
+public final class CliWorkspaceLayouts {
+
+    private CliWorkspaceLayouts() {
+    }
+
+    public static List<WorkspaceDescriptor> resolve(Path repositoryRoot, List<Path> cliSourceRoots)
+            throws IOException {
+        Path normalizedRoot = repositoryRoot.toAbsolutePath().normalize();
+        if (cliSourceRoots != null && !cliSourceRoots.isEmpty()) {
+            List<Path> roots = ProjectParser.resolveSourceRoots(normalizedRoot, cliSourceRoots);
+            String nameFromRootDir = normalizedRoot.getFileName().toString();
+            ModuleDescriptor lone = new ModuleDescriptor(nameFromRootDir, normalizedRoot, roots);
+            return List.of(new WorkspaceDescriptor(nameFromRootDir, normalizedRoot, List.of(lone)));
+        }
+        List<WorkspaceDescriptor> workspaces = RepositoryLayoutDetector.detect(normalizedRoot);
+        if (workspaces.isEmpty()) {
+            return fallbackSingletonWorkspace(normalizedRoot);
+        }
+        return workspaces;
+    }
+
+    /** Last resort: single conceptual module under {@link ProjectParser#resolveSourceRoots(Path, List)} semantics. */
+    private static List<WorkspaceDescriptor> fallbackSingletonWorkspace(Path repositoryRoot) {
+        Path javaRootOnly = repositoryRoot.resolve("src/main/java").toAbsolutePath().normalize();
+        String workspaceName = repositoryRoot.getFileName().toString();
+        ModuleDescriptor moduleDescriptor =
+                new ModuleDescriptor(workspaceName, repositoryRoot, List.of(javaRootOnly));
+        return List.of(new WorkspaceDescriptor(workspaceName, repositoryRoot, List.of(moduleDescriptor)));
+    }
+
+    public static String collectionName(String userCollectionInput, WorkspaceDescriptor workspace, int workspacesCount) {
+        boolean supplied = userCollectionInput != null && !userCollectionInput.isBlank();
+        if (!supplied) {
+            return workspace.name();
+        }
+        if (workspacesCount <= 1) {
+            return userCollectionInput.strip();
+        }
+        return userCollectionInput.strip() + "__" + workspace.name();
+    }
+
+    /**
+     * State directory for checksums: default is {@code {workspace}/.graphus}; when {@code userStateDirOverride}
+     * is set and multiple workspaces resolve from {@code --repo}, shards go under {@code userStateDirOverride/<workspace name>}.
+     */
+    public static Path stateDirectory(
+            Path userStateDirOverride,
+            WorkspaceDescriptor workspace,
+            int workspacesCount) {
+        if (userStateDirOverride != null) {
+            if (workspacesCount <= 1) {
+                return userStateDirOverride;
+            }
+            return userStateDirOverride.resolve(workspace.name());
+        }
+        return workspace.root().resolve(".graphus");
+    }
+}

--- a/graphus-cli/src/main/java/io/graphus/cli/GraphusCommand.java
+++ b/graphus-cli/src/main/java/io/graphus/cli/GraphusCommand.java
@@ -7,15 +7,20 @@ import io.graphus.indexer.FileChangeSet;
 import io.graphus.indexer.FileChecksumRegistry;
 import io.graphus.indexer.GraphIndexer;
 import io.graphus.indexer.GraphSearchHit;
+import io.graphus.indexer.SymbolChunkBuilder;
 import io.graphus.model.CallGraph;
+import io.graphus.model.WorkspaceDescriptor;
 import io.graphus.parser.ProjectParser;
 import io.graphus.parser.ProjectParserResult;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.time.Duration;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.LinkedHashMap;
 import java.util.Locale;
+import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.Callable;
 import picocli.CommandLine;
@@ -72,55 +77,77 @@ public final class GraphusCommand implements Callable<Integer> {
         @Option(names = "--embedding", defaultValue = "local", description = "Embedding backend: local|openai")
         private String embeddingBackend;
 
-        @Option(names = "--state-dir", description = "Directory where checksums.json is stored (default: {repo}/.graphus)")
+        @Option(names = "--state-dir", description = "Directory where checksums.json is stored (default: .graphus per workspace)")
         private Path stateDir;
 
         @Override
         public Integer call() throws Exception {
             long totalStartNanos = System.nanoTime();
             Path repoRoot = repositoryRoot.toAbsolutePath().normalize();
-            String resolvedCollectionName = (collectionName != null && !collectionName.isBlank())
-                    ? collectionName
-                    : repoRoot.getFileName().toString();
-            Path resolvedStateDir = stateDir != null ? stateDir : repoRoot.resolve(".graphus");
-            List<Path> normalizedSourceRoots = ProjectParser.resolveSourceRoots(repoRoot, sourceRoots);
+            List<WorkspaceDescriptor> workspaces = CliWorkspaceLayouts.resolve(repoRoot, sourceRoots);
 
-            var embeddingModel = new EmbeddingModelFactory().create(parseEmbeddingBackend(embeddingBackend));
-            var embeddingStore = GraphIndexer.chromaStore(
-                    chromaUrl,
-                    resolvedCollectionName,
-                    Duration.ofSeconds(Math.max(1, chromaTimeoutSeconds))
-            );
-            GraphIndexer graphIndexer = new GraphIndexer(embeddingModel, embeddingStore, Math.max(1, batchSize));
+            int totalParsed = 0;
+            int totalUnresolved = 0;
+            int indexedSymbolsAccumulator = 0;
 
-            System.out.println(phase("Clearing existing index..."));
-            long clearStartNanos = System.nanoTime();
-            graphIndexer.removeAll();
-            System.out.println(timing("Clear time      : ", formatElapsed(clearStartNanos)));
+            ProjectParser projectParser = new ProjectParser();
 
-            long parseStartNanos = System.nanoTime();
-            ParserProgressReporter reporter = new ParserProgressReporter();
-            ProjectParserResult parseResult = new ProjectParser().parse(repoRoot, sourceRoots, reporter);
-            reporter.complete();
-            System.out.println(timing("Parse time      : ", formatElapsed(parseStartNanos)));
+            for (WorkspaceDescriptor workspace : workspaces) {
+                String resolvedCollection =
+                        CliWorkspaceLayouts.collectionName(collectionName, workspace, workspaces.size());
+                Path resolvedStateDir =
+                        CliWorkspaceLayouts.stateDirectory(stateDir, workspace, workspaces.size());
+                List<Path> normalizedRoots = workspace.flattenedSourceRoots();
 
-            long indexStartNanos = System.nanoTime();
-            IndexProgressReporter indexReporter = new IndexProgressReporter();
-            int indexedSymbols = graphIndexer.index(parseResult.callGraph(), indexReporter);
-            indexReporter.complete();
-            System.out.println(timing("Index time      : ", formatElapsed(indexStartNanos)));
+                var embeddingModel = new EmbeddingModelFactory().create(parseEmbeddingBackend(embeddingBackend));
+                var embeddingStore = GraphIndexer.chromaStore(
+                        chromaUrl,
+                        resolvedCollection,
+                        Duration.ofSeconds(Math.max(1, chromaTimeoutSeconds))
+                );
+                GraphIndexer graphIndexer =
+                        new GraphIndexer(embeddingModel, embeddingStore, Math.max(1, batchSize));
 
-            System.out.println(phase("Saving checksum registry..."));
-            long checksumStartNanos = System.nanoTime();
-            FileChecksumRegistry registry = FileChecksumRegistry.empty();
-            registry.recomputeAll(repoRoot, normalizedSourceRoots);
-            registry.save(resolvedStateDir);
-            System.out.println(timing("Checksum time   : ", formatElapsed(checksumStartNanos)));
+                System.out.println(phase(
+                        "Workspace [" + workspace.name() + "] collection=" + resolvedCollection));
 
-            System.out.println(summary("Parsed files    : ", Integer.toString(parseResult.parsedFiles())));
-            System.out.println(summary("Unresolved calls: ", Integer.toString(parseResult.unresolvedCalls())));
-            System.out.println(summary("Indexed symbols : ", Integer.toString(indexedSymbols)));
-            System.out.println(summary("Registry saved  : ", resolvedStateDir.resolve("checksums.json").toString()));
+                System.out.println(phase("Clearing existing index..."));
+                long clearStartNanos = System.nanoTime();
+                graphIndexer.removeAll();
+                System.out.println(timing("Clear time      : ", formatElapsed(clearStartNanos)));
+
+                long parseStartNanos = System.nanoTime();
+                ParserProgressReporter reporter = new ParserProgressReporter();
+                ProjectParserResult parseResult = projectParser.parse(workspace, reporter);
+                reporter.complete();
+                System.out.println(timing("Parse time      : ", formatElapsed(parseStartNanos)));
+
+                long indexStartNanos = System.nanoTime();
+                IndexProgressReporter indexReporter = new IndexProgressReporter();
+                indexedSymbolsAccumulator += graphIndexer.index(parseResult.callGraph(), workspace, indexReporter);
+                indexReporter.complete();
+                System.out.println(timing("Index time      : ", formatElapsed(indexStartNanos)));
+
+                System.out.println(phase("Saving checksum registry..."));
+                long checksumStartNanos = System.nanoTime();
+                FileChecksumRegistry registry = FileChecksumRegistry.empty();
+                registry.recomputeAll(workspace.root(), normalizedRoots);
+                registry.save(resolvedStateDir);
+                System.out.println(timing("Checksum time   : ", formatElapsed(checksumStartNanos)));
+
+                totalParsed += parseResult.parsedFiles();
+                totalUnresolved += parseResult.unresolvedCalls();
+
+                System.out.println(summary(
+                        "Registry saved  : ", resolvedStateDir.resolve("checksums.json").toString()));
+                System.out.println(Ansi.style("---", Ansi.DIM));
+            }
+
+            System.out.println(summary("Parsed files    : ", Integer.toString(totalParsed)));
+            System.out.println(summary("Unresolved calls: ", Integer.toString(totalUnresolved)));
+            System.out.println(summary(
+                    "Indexed symbols : ",
+                    Integer.toString(indexedSymbolsAccumulator)));
             System.out.println(summary("Total time      : ", formatElapsed(totalStartNanos)));
             return 0;
         }
@@ -150,88 +177,129 @@ public final class GraphusCommand implements Callable<Integer> {
         @Option(names = "--embedding", defaultValue = "local", description = "Embedding backend: local|openai")
         private String embeddingBackend;
 
-        @Option(names = "--state-dir", description = "Directory where checksums.json is stored (default: {repo}/.graphus)")
+        @Option(names = "--state-dir", description = "Directory where checksums.json is stored (default: .graphus per workspace)")
         private Path stateDir;
 
         @Override
         public Integer call() throws Exception {
             long totalStartNanos = System.nanoTime();
             Path repoRoot = repositoryRoot.toAbsolutePath().normalize();
-            String resolvedCollectionName = (collectionName != null && !collectionName.isBlank())
-                    ? collectionName
-                    : repoRoot.getFileName().toString();
-            Path resolvedStateDir = stateDir != null ? stateDir : repoRoot.resolve(".graphus");
-            List<Path> normalizedSourceRoots = ProjectParser.resolveSourceRoots(repoRoot, sourceRoots);
+            List<WorkspaceDescriptor> workspaces = CliWorkspaceLayouts.resolve(repoRoot, sourceRoots);
 
-            if (!FileChecksumRegistry.exists(resolvedStateDir)) {
-                System.err.println(error("No index found. Run 'graphus index' first."));
-                return 1;
+            int indexedSymbolsAccumulator = 0;
+
+            ProjectParser projectParser = new ProjectParser();
+
+            for (WorkspaceDescriptor workspace : workspaces) {
+                String resolvedCollection =
+                        CliWorkspaceLayouts.collectionName(collectionName, workspace, workspaces.size());
+                Path resolvedStateDir =
+                        CliWorkspaceLayouts.stateDirectory(stateDir, workspace, workspaces.size());
+
+                List<Path> normalizedRoots = workspace.flattenedSourceRoots();
+
+                if (!FileChecksumRegistry.exists(resolvedStateDir)) {
+                    System.err.println(
+                            error(
+                                    "No index found for workspace ["
+                                            + workspace.name()
+                                            + "]. Run 'graphus index' first."));
+                    return 1;
+                }
+
+                System.out.println(phase(
+                        "Workspace [" + workspace.name() + "] collection=" + resolvedCollection));
+
+                System.out.println(phase("Loading checksum registry..."));
+                long loadRegistryStartNanos = System.nanoTime();
+                FileChecksumRegistry registry = FileChecksumRegistry.load(resolvedStateDir);
+                System.out.println(timing("Load time       : ", formatElapsed(loadRegistryStartNanos)));
+
+                System.out.println(phase("Scanning source files for changes..."));
+                long scanStartNanos = System.nanoTime();
+                FileChangeSet changes = registry.diffAndUpdate(workspace.root(), normalizedRoots);
+                System.out.println(timing("Scan time       : ", formatElapsed(scanStartNanos)));
+
+                int totalFiles = FileChecksumRegistry.discoverJavaFiles(normalizedRoots).size();
+                System.out.println(summary("Files scanned   : ", Integer.toString(totalFiles)));
+                System.out.println(summary("Added           : ", Integer.toString(changes.added().size())));
+                System.out.println(summary("Modified        : ", Integer.toString(changes.modified().size())));
+                System.out.println(summary("Deleted         : ", Integer.toString(changes.deleted().size())));
+
+                if (!changes.hasChanges()) {
+                    System.out.println(phase("Nothing to sync. Index is up to date."));
+                    System.out.println(Ansi.style("---", Ansi.DIM));
+                    continue;
+                }
+
+                var embeddingModel = new EmbeddingModelFactory().create(parseEmbeddingBackend(embeddingBackend));
+                var embeddingStore = GraphIndexer.chromaStore(
+                        chromaUrl,
+                        resolvedCollection,
+                        Duration.ofSeconds(Math.max(1, chromaTimeoutSeconds))
+                );
+                GraphIndexer graphIndexer =
+                        new GraphIndexer(embeddingModel, embeddingStore, Math.max(1, batchSize));
+
+                long removeStartNanos = System.nanoTime();
+                int removedFiles = 0;
+                for (String filePath : changes.modified()) {
+                    graphIndexer.removeByFile(filePath);
+                    removedFiles++;
+                }
+                for (String filePath : changes.deleted()) {
+                    graphIndexer.removeByFile(filePath);
+                    removedFiles++;
+                }
+                System.out.println(summary("Files removed from index: ", Integer.toString(removedFiles)));
+                System.out.println(timing("Remove time     : ", formatElapsed(removeStartNanos)));
+
+                Set<String> toReindex = changes.toReindex();
+                int indexedThisWorkspace = 0;
+                if (!toReindex.isEmpty()) {
+                    long parseStartNanos = System.nanoTime();
+                    ParserProgressReporter reporter = new ParserProgressReporter();
+                    ProjectParserResult parseResult = projectParser.parse(workspace, reporter);
+                    reporter.complete();
+                    System.out.println(timing("Parse time      : ", formatElapsed(parseStartNanos)));
+
+                    long indexStartNanos = System.nanoTime();
+                    IndexProgressReporter indexReporter = new IndexProgressReporter();
+                    if (workspace.isMultiModule()) {
+                        Map<String, Set<String>> byModule = filesGroupedByModuleTag(workspace, toReindex);
+                        for (Map.Entry<String, Set<String>> entry : byModule.entrySet()) {
+                            indexedThisWorkspace += graphIndexer.indexForFiles(
+                                    parseResult.callGraph(),
+                                    workspace,
+                                    entry.getValue(),
+                                    indexReporter);
+                        }
+                    } else {
+                        indexedThisWorkspace +=
+                                graphIndexer.indexForFiles(
+                                        parseResult.callGraph(),
+                                        toReindex,
+                                        indexReporter);
+                    }
+                    indexReporter.complete();
+                    System.out.println(timing("Index time      : ", formatElapsed(indexStartNanos)));
+                }
+
+                System.out.println(phase("Saving updated checksum registry..."));
+                long checksumStartNanos = System.nanoTime();
+                registry.save(resolvedStateDir);
+                System.out.println(timing("Checksum time   : ", formatElapsed(checksumStartNanos)));
+
+                indexedSymbolsAccumulator += indexedThisWorkspace;
+
+                System.out.println(
+                        summary("Symbols indexed : ", Integer.toString(indexedThisWorkspace)));
+                System.out.println(Ansi.style("---", Ansi.DIM));
             }
 
-            System.out.println(phase("Loading checksum registry..."));
-            long loadRegistryStartNanos = System.nanoTime();
-            FileChecksumRegistry registry = FileChecksumRegistry.load(resolvedStateDir);
-            System.out.println(timing("Load time       : ", formatElapsed(loadRegistryStartNanos)));
-
-            System.out.println(phase("Scanning source files for changes..."));
-            long scanStartNanos = System.nanoTime();
-            FileChangeSet changes = registry.diffAndUpdate(repoRoot, normalizedSourceRoots);
-            System.out.println(timing("Scan time       : ", formatElapsed(scanStartNanos)));
-
-            int totalFiles = FileChecksumRegistry.discoverJavaFiles(normalizedSourceRoots).size();
-            System.out.println(summary("Files scanned   : ", Integer.toString(totalFiles)));
-            System.out.println(summary("Added           : ", Integer.toString(changes.added().size())));
-            System.out.println(summary("Modified        : ", Integer.toString(changes.modified().size())));
-            System.out.println(summary("Deleted         : ", Integer.toString(changes.deleted().size())));
-
-            if (!changes.hasChanges()) {
-                System.out.println(phase("Nothing to sync. Index is up to date."));
-                return 0;
-            }
-
-            var embeddingModel = new EmbeddingModelFactory().create(parseEmbeddingBackend(embeddingBackend));
-            var embeddingStore = GraphIndexer.chromaStore(
-                    chromaUrl,
-                    resolvedCollectionName,
-                    Duration.ofSeconds(Math.max(1, chromaTimeoutSeconds))
-            );
-            GraphIndexer graphIndexer = new GraphIndexer(embeddingModel, embeddingStore, Math.max(1, batchSize));
-
-            long removeStartNanos = System.nanoTime();
-            int removedFiles = 0;
-            for (String filePath : changes.modified()) {
-                graphIndexer.removeByFile(filePath);
-                removedFiles++;
-            }
-            for (String filePath : changes.deleted()) {
-                graphIndexer.removeByFile(filePath);
-                removedFiles++;
-            }
-            System.out.println(summary("Files removed from index: ", Integer.toString(removedFiles)));
-            System.out.println(timing("Remove time     : ", formatElapsed(removeStartNanos)));
-
-            Set<String> toReindex = changes.toReindex();
-            int indexedSymbols = 0;
-            if (!toReindex.isEmpty()) {
-                long parseStartNanos = System.nanoTime();
-                ParserProgressReporter reporter = new ParserProgressReporter();
-                ProjectParserResult parseResult = new ProjectParser().parse(repoRoot, sourceRoots, reporter);
-                reporter.complete();
-                System.out.println(timing("Parse time      : ", formatElapsed(parseStartNanos)));
-
-                long indexStartNanos = System.nanoTime();
-                IndexProgressReporter indexReporter = new IndexProgressReporter();
-                indexedSymbols = graphIndexer.indexForFiles(parseResult.callGraph(), toReindex, indexReporter);
-                indexReporter.complete();
-                System.out.println(timing("Index time      : ", formatElapsed(indexStartNanos)));
-            }
-
-            System.out.println(phase("Saving updated checksum registry..."));
-            long checksumStartNanos = System.nanoTime();
-            registry.save(resolvedStateDir);
-            System.out.println(timing("Checksum time   : ", formatElapsed(checksumStartNanos)));
-
-            System.out.println(summary("Symbols indexed : ", Integer.toString(indexedSymbols)));
+            System.out.println(summary(
+                    "Total symbols indexed across workspaces: ",
+                    Integer.toString(indexedSymbolsAccumulator)));
             System.out.println(summary("Total time      : ", formatElapsed(totalStartNanos)));
             return 0;
         }
@@ -255,6 +323,9 @@ public final class GraphusCommand implements Callable<Integer> {
         @Option(names = "--top-k", defaultValue = "10", description = "Number of hits")
         private int topK;
 
+        @Option(names = "--module", description = "Restrict hits to embeddings tagged with this module name")
+        private String moduleFilter;
+
         @Override
         public Integer call() {
             String resolvedCollectionName = (collectionName != null && !collectionName.isBlank())
@@ -263,10 +334,16 @@ public final class GraphusCommand implements Callable<Integer> {
             var embeddingModel = new EmbeddingModelFactory().create(parseEmbeddingBackend(embeddingBackend));
             var embeddingStore = GraphIndexer.chromaStore(chromaUrl, resolvedCollectionName);
             GraphIndexer graphIndexer = new GraphIndexer(embeddingModel, embeddingStore);
-            List<GraphSearchHit> hits = graphIndexer.query(question, topK);
+            String module = moduleFilter == null || moduleFilter.isBlank() ? null : moduleFilter.strip();
+            List<GraphSearchHit> hits = graphIndexer.query(question, module, topK);
 
             if (hits.isEmpty()) {
                 System.out.println(phase("No results."));
+                if (module != null) {
+                    System.err.println(error(
+                            "No results for module='" + module
+                                    + "'. This collection may not have been indexed with module tags."));
+                }
                 return 0;
             }
 
@@ -304,9 +381,21 @@ public final class GraphusCommand implements Callable<Integer> {
 
         @Override
         public Integer call() throws Exception {
+            Path repoRoot = repositoryRoot.toAbsolutePath().normalize();
+            List<WorkspaceDescriptor> workspaces = CliWorkspaceLayouts.resolve(repoRoot, sourceRoots);
+            if (workspaces.size() != 1) {
+                System.err.println(
+                        error(
+                                "Blast radius requires exactly one analysable workspace. Found "
+                                        + workspaces.size()
+                                        + ". Narrow --repo, use --source, or run from inside a single project."));
+                return 1;
+            }
+            WorkspaceDescriptor workspaceContext = workspaces.get(0);
+
             ProjectParser projectParser = new ProjectParser();
             ParserProgressReporter reporter = new ParserProgressReporter();
-            ProjectParserResult parseResult = projectParser.parse(repositoryRoot, sourceRoots, reporter);
+            ProjectParserResult parseResult = projectParser.parse(workspaceContext, reporter);
             reporter.complete();
             CallGraph callGraph = parseResult.callGraph();
 
@@ -340,6 +429,18 @@ public final class GraphusCommand implements Callable<Integer> {
                     .findFirst()
                     .orElse(null);
         }
+    }
+
+    /** Groups repository-relative paths by {@code module} embedding tag assignment. */
+    private static Map<String, Set<String>> filesGroupedByModuleTag(
+            WorkspaceDescriptor workspaceDescriptor, Iterable<String> filePaths) {
+        Map<String, Set<String>> accumulator = new LinkedHashMap<>();
+        for (String filePath : filePaths) {
+            String moduleTag =
+                    SymbolChunkBuilder.resolveModuleMetadataTag(filePath, workspaceDescriptor);
+            accumulator.computeIfAbsent(moduleTag, ignored -> new HashSet<>()).add(filePath);
+        }
+        return accumulator;
     }
 
     private static EmbeddingBackend parseEmbeddingBackend(String value) {

--- a/graphus-indexer/build.gradle.kts
+++ b/graphus-indexer/build.gradle.kts
@@ -10,7 +10,4 @@ dependencies {
     implementation("dev.langchain4j:langchain4j-embeddings-all-minilm-l6-v2:1.14.0-beta24")
     implementation("com.fasterxml.jackson.core:jackson-databind:2.21.3")
     implementation("org.slf4j:slf4j-api:2.0.17")
-
-    testImplementation(platform("org.junit:junit-bom:5.11.4"))
-    testImplementation("org.junit.jupiter:junit-jupiter")
 }

--- a/graphus-indexer/src/main/java/io/graphus/indexer/GraphIndexer.java
+++ b/graphus-indexer/src/main/java/io/graphus/indexer/GraphIndexer.java
@@ -11,6 +11,7 @@ import dev.langchain4j.store.embedding.chroma.ChromaApiVersion;
 import dev.langchain4j.store.embedding.chroma.ChromaEmbeddingStore;
 import dev.langchain4j.store.embedding.filter.comparison.IsEqualTo;
 import io.graphus.model.CallGraph;
+import io.graphus.model.WorkspaceDescriptor;
 import java.time.Duration;
 import java.util.List;
 import java.util.Map;
@@ -58,6 +59,20 @@ public final class GraphIndexer {
         return indexChunks(chunks, progressListener);
     }
 
+    public int index(CallGraph callGraph, WorkspaceDescriptor workspaceDescriptor) {
+        return index(callGraph, workspaceDescriptor, (chunk, current, total) -> {});
+    }
+
+    public int index(
+            CallGraph callGraph,
+            WorkspaceDescriptor workspaceDescriptor,
+            IndexProgressListener progressListener) {
+        List<SymbolChunk> chunks = workspaceDescriptor.isMultiModule()
+                ? symbolChunkBuilder.build(callGraph, workspaceDescriptor)
+                : symbolChunkBuilder.build(callGraph);
+        return indexChunks(chunks, progressListener);
+    }
+
     /**
      * Removes all documents from the embedding store. Use before a full re-index.
      */
@@ -74,6 +89,16 @@ public final class GraphIndexer {
     }
 
     /**
+     * Removes embeddings whose {@code module} metadata field matches exactly.
+     */
+    public void removeByModule(String moduleName) {
+        if (moduleName == null || moduleName.isBlank()) {
+            return;
+        }
+        embeddingStore.removeAll(new IsEqualTo("module", moduleName));
+    }
+
+    /**
      * Indexes only the symbols belonging to the given set of relative file paths.
      * Useful for incremental sync where only changed files need re-embedding.
      */
@@ -83,6 +108,17 @@ public final class GraphIndexer {
 
     public int indexForFiles(CallGraph callGraph, Set<String> filePaths, IndexProgressListener progressListener) {
         List<SymbolChunk> filteredChunks = symbolChunkBuilder.build(callGraph, filePaths);
+        return indexChunks(filteredChunks, progressListener);
+    }
+
+    public int indexForFiles(
+            CallGraph callGraph,
+            WorkspaceDescriptor workspaceDescriptor,
+            Set<String> filePaths,
+            IndexProgressListener progressListener) {
+        List<SymbolChunk> filteredChunks = workspaceDescriptor.isMultiModule()
+                ? symbolChunkBuilder.build(callGraph, workspaceDescriptor, filePaths)
+                : symbolChunkBuilder.build(callGraph, filePaths);
         return indexChunks(filteredChunks, progressListener);
     }
 
@@ -103,12 +139,21 @@ public final class GraphIndexer {
     }
 
     public List<GraphSearchHit> query(String question, int topK) {
+        return query(question, null, topK);
+    }
+
+    public List<GraphSearchHit> query(String question, String moduleFilter, int topK) {
         Embedding queryEmbedding = embeddingModel.embed(question).content();
-        EmbeddingSearchRequest request = EmbeddingSearchRequest.builder()
-                .queryEmbedding(queryEmbedding)
-                .maxResults(Math.max(1, topK))
-                .build();
-        EmbeddingSearchResult<TextSegment> result = embeddingStore.search(request);
+
+        EmbeddingSearchRequest.EmbeddingSearchRequestBuilder requestBuilder =
+                EmbeddingSearchRequest.builder()
+                        .queryEmbedding(queryEmbedding)
+                        .maxResults(Math.max(1, topK));
+        if (moduleFilter != null && !moduleFilter.isBlank()) {
+            requestBuilder = requestBuilder.filter(new IsEqualTo("module", moduleFilter));
+        }
+
+        EmbeddingSearchResult<TextSegment> result = embeddingStore.search(requestBuilder.build());
         return result.matches().stream()
                 .map(this::toSearchHit)
                 .toList();

--- a/graphus-indexer/src/main/java/io/graphus/indexer/SymbolChunkBuilder.java
+++ b/graphus-indexer/src/main/java/io/graphus/indexer/SymbolChunkBuilder.java
@@ -5,19 +5,31 @@ import io.graphus.model.CallGraph;
 import io.graphus.model.ClassNode;
 import io.graphus.model.FieldNode;
 import io.graphus.model.MethodNode;
+import io.graphus.model.ModuleDescriptor;
 import io.graphus.model.SymbolKind;
 import io.graphus.model.SymbolNode;
 import io.graphus.model.UnresolvedNode;
+import io.graphus.model.WorkspaceDescriptor;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
 public final class SymbolChunkBuilder {
 
     public List<SymbolChunk> build(CallGraph callGraph) {
-        return buildChunks(callGraph.getNodes(), callGraph);
+        return buildChunks(callGraph.getNodes(), callGraph, Optional.empty());
+    }
+
+    public List<SymbolChunk> build(CallGraph callGraph, WorkspaceDescriptor workspace) {
+        if (!workspace.isMultiModule()) {
+            return build(callGraph);
+        }
+        return buildChunks(callGraph.getNodes(), callGraph, Optional.of(workspace));
     }
 
     public List<SymbolChunk> build(CallGraph callGraph, Set<String> filePaths) {
@@ -25,15 +37,30 @@ public final class SymbolChunkBuilder {
                 callGraph.getNodes().stream()
                         .filter(node -> filePaths.contains(node.getFilePath()))
                         .toList(),
-                callGraph
+                callGraph,
+                Optional.empty()
         );
     }
 
-    private List<SymbolChunk> buildChunks(Collection<SymbolNode> nodes, CallGraph callGraph) {
+    public List<SymbolChunk> build(CallGraph callGraph, WorkspaceDescriptor workspace, Set<String> filePaths) {
+        if (!workspace.isMultiModule()) {
+            return build(callGraph, filePaths);
+        }
+        return buildChunks(
+                callGraph.getNodes().stream()
+                        .filter(node -> filePaths.contains(node.getFilePath()))
+                        .toList(),
+                callGraph,
+                Optional.of(workspace)
+        );
+    }
+
+    private List<SymbolChunk> buildChunks(Collection<SymbolNode> nodes, CallGraph callGraph,
+            Optional<WorkspaceDescriptor> workspace) {
         List<SymbolChunk> chunks = new ArrayList<>();
 
         for (SymbolNode node : nodes) {
-            Metadata metadata = metadataFor(node);
+            Metadata metadata = metadataFor(node, workspace);
             String text = chunkText(node, callGraph);
             chunks.add(new SymbolChunk(node.getId(), text, metadata));
         }
@@ -41,7 +68,16 @@ public final class SymbolChunkBuilder {
         return chunks;
     }
 
-    private Metadata metadataFor(SymbolNode node) {
+    private Metadata metadataFor(SymbolNode node, Optional<WorkspaceDescriptor> workspace) {
+        Metadata metadata = baseMetadataFor(node);
+        if (workspace.isPresent()) {
+            String moduleTag = resolveModuleMetadataTag(node.getFilePath(), workspace.get());
+            metadata = metadata.put("module", moduleTag);
+        }
+        return metadata;
+    }
+
+    private Metadata baseMetadataFor(SymbolNode node) {
         Metadata metadata = new Metadata()
                 .put("fqn", node.getId())
                 .put("kind", node.getKind().name())
@@ -124,5 +160,37 @@ public final class SymbolChunkBuilder {
                     + "File: " + unresolvedNode.getFilePath() + ":" + unresolvedNode.getLine();
         }
         return "[SYMBOL] " + node.getId();
+    }
+
+    /**
+     * Resolves repository-relative {@linkplain SymbolNode#getFilePath()} to a {@linkplain ModuleDescriptor#name()},
+     * using the longest matching workspace-relative source-root prefix across all modules.
+     */
+    public static String resolveModuleMetadataTag(String filePath, WorkspaceDescriptor workspace) {
+        if (filePath == null || filePath.isBlank()) {
+            return "unknown";
+        }
+        Path normalizedFile = Paths.get(filePath.trim()).normalize();
+        Path workspaceRootAbs = workspace.root().toAbsolutePath().normalize();
+
+        Path bestMatchingPrefix = null;
+        String owningModuleName = null;
+
+        for (ModuleDescriptor moduleDescriptor : workspace.modules()) {
+            for (Path absoluteSourceRoot : moduleDescriptor.sourceRoots()) {
+                Path relativeRoot = workspaceRootAbs.relativize(absoluteSourceRoot).normalize();
+                if (!normalizedFile.startsWith(relativeRoot)) {
+                    continue;
+                }
+                boolean better = bestMatchingPrefix == null
+                        || relativeRoot.getNameCount() > bestMatchingPrefix.getNameCount();
+
+                if (better) {
+                    bestMatchingPrefix = relativeRoot;
+                    owningModuleName = moduleDescriptor.name();
+                }
+            }
+        }
+        return owningModuleName != null ? owningModuleName : "unknown";
     }
 }

--- a/graphus-indexer/src/test/java/io/graphus/indexer/SymbolChunkBuilderWorkspaceTest.java
+++ b/graphus-indexer/src/test/java/io/graphus/indexer/SymbolChunkBuilderWorkspaceTest.java
@@ -1,0 +1,73 @@
+package io.graphus.indexer;
+
+import io.graphus.model.CallGraph;
+import io.graphus.model.ClassNode;
+import io.graphus.model.ModuleDescriptor;
+import io.graphus.model.WorkspaceDescriptor;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class SymbolChunkBuilderWorkspaceTest {
+
+    @Test
+    void tagsChunksPerModuleDescriptor(@TempDir Path tempDir) {
+        Path mono = tempDir.resolve("mono-root").normalize();
+        Path coreJava = mono.resolve("core/src/main/java").toAbsolutePath().normalize();
+        Path apiJava = mono.resolve("api/src/main/java").toAbsolutePath().normalize();
+
+        ModuleDescriptor core =
+                new ModuleDescriptor("core", mono.resolve("core").toAbsolutePath().normalize(),
+                        List.of(coreJava));
+        ModuleDescriptor api =
+                new ModuleDescriptor("api", mono.resolve("api").toAbsolutePath().normalize(),
+                        List.of(apiJava));
+        WorkspaceDescriptor workspace =
+                new WorkspaceDescriptor(mono.getFileName().toString(),
+                        mono.toAbsolutePath().normalize(),
+                        List.of(core, api));
+
+        CallGraph graph = new CallGraph();
+        ClassNode clsCore = minimalClass("demo.Core", "core/src/main/java/Demo.java", 12);
+        ClassNode clsApi = minimalClass("demo.Api", "api/src/main/java/Demo.java", 20);
+
+        graph.addNode(clsCore);
+        graph.addNode(clsApi);
+
+        SymbolChunkBuilder builder = new SymbolChunkBuilder();
+        List<SymbolChunk> chunks = builder.build(graph, workspace);
+        List<String> moduleMetadata = chunks.stream()
+                .map(c -> String.valueOf(c.metadata().toMap().get("module")))
+                .sorted()
+                .toList();
+
+        assertEquals(List.of("api", "core"), moduleMetadata);
+
+        List<SymbolChunk> subsetChunks =
+                builder.build(graph, workspace, Set.of(clsCore.getFilePath()));
+        assertEquals(1, subsetChunks.size());
+        assertEquals("core", subsetChunks.get(0).metadata().toMap().get("module"));
+    }
+
+    private static ClassNode minimalClass(String id, String repoRelativePath, int line) {
+        return new ClassNode(
+                id,
+                simpleName(id),
+                repoRelativePath,
+                line,
+                List.of(),
+                null,
+                List.of(),
+                null,
+                null);
+    }
+
+    private static String simpleName(String qualified) {
+        int dot = qualified.lastIndexOf('.');
+        return dot >= 0 ? qualified.substring(dot + 1) : qualified;
+    }
+}

--- a/graphus-model/build.gradle.kts
+++ b/graphus-model/build.gradle.kts
@@ -1,8 +1,3 @@
 plugins {
     id("graphus.java-conventions")
 }
-
-dependencies {
-    testImplementation(platform("org.junit:junit-bom:5.11.4"))
-    testImplementation("org.junit.jupiter:junit-jupiter")
-}

--- a/graphus-model/src/main/java/io/graphus/model/ModuleDescriptor.java
+++ b/graphus-model/src/main/java/io/graphus/model/ModuleDescriptor.java
@@ -1,0 +1,31 @@
+package io.graphus.model;
+
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Describes one Gradle/Maven module or a single-module codebase root inside a workspace.
+ *
+ * @param name         logical module name used for tagging (directory name segment)
+ * @param root         module root directory (absolute, normalized); for a single-module repo,
+ *                     equals the workspace root
+ * @param sourceRoots normalized absolute directories containing {@code *.java}
+ */
+public record ModuleDescriptor(String name, Path root, List<Path> sourceRoots) {
+
+    public ModuleDescriptor {
+        if (name == null || name.isBlank()) {
+            throw new IllegalArgumentException("name must not be blank");
+        }
+        if (root == null || sourceRoots == null || sourceRoots.isEmpty()) {
+            throw new IllegalArgumentException("root and sourceRoots must not be null or empty");
+        }
+        root = root.toAbsolutePath().normalize();
+        List<Path> normalizedRoots = new ArrayList<>();
+        for (Path sourceRoot : sourceRoots) {
+            normalizedRoots.add(sourceRoot.toAbsolutePath().normalize());
+        }
+        sourceRoots = List.copyOf(normalizedRoots);
+    }
+}

--- a/graphus-model/src/main/java/io/graphus/model/WorkspaceDescriptor.java
+++ b/graphus-model/src/main/java/io/graphus/model/WorkspaceDescriptor.java
@@ -1,0 +1,41 @@
+package io.graphus.model;
+
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Describes a codebase layout Graphus analyses as one parsing/indexing workspace.
+ *
+ * @param name    collection name suggestion (typically the workspace root folder name)
+ * @param root    workspace root containing source (absolute, normalized)
+ * @param modules one or more {@link ModuleDescriptor} entries defining source roots under {@code root}
+ */
+public record WorkspaceDescriptor(String name, Path root, List<ModuleDescriptor> modules) {
+
+    public WorkspaceDescriptor {
+        if (name == null || name.isBlank()) {
+            throw new IllegalArgumentException("name must not be blank");
+        }
+        if (root == null || modules == null || modules.isEmpty()) {
+            throw new IllegalArgumentException("root and modules must not be null or empty");
+        }
+        modules = List.copyOf(modules);
+        root = root.toAbsolutePath().normalize();
+    }
+
+    /** True when more than one module exists (chunks should carry a {@code module} metadata tag). */
+    public boolean isMultiModule() {
+        return modules.size() > 1;
+    }
+
+    /** All {@link ModuleDescriptor#sourceRoots()} in declaration order for checksum and parsing orchestration. */
+    public List<Path> flattenedSourceRoots() {
+        List<Path> sourceRoots = new ArrayList<>();
+        for (ModuleDescriptor module : modules) {
+            sourceRoots.addAll(module.sourceRoots());
+        }
+        return Collections.unmodifiableList(sourceRoots);
+    }
+}

--- a/graphus-parser/build.gradle.kts
+++ b/graphus-parser/build.gradle.kts
@@ -6,7 +6,4 @@ dependencies {
     implementation(project(":graphus-model"))
     implementation("com.github.javaparser:javaparser-symbol-solver-core:3.27.1")
     implementation("org.slf4j:slf4j-api:2.0.17")
-
-    testImplementation(platform("org.junit:junit-bom:5.11.4"))
-    testImplementation("org.junit.jupiter:junit-jupiter")
 }

--- a/graphus-parser/src/main/java/io/graphus/parser/GradleSettingsParser.java
+++ b/graphus-parser/src/main/java/io/graphus/parser/GradleSettingsParser.java
@@ -1,0 +1,129 @@
+package io.graphus.parser;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.StringJoiner;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Lightweight extraction of Gradle {@code include(\"...\")} module paths from settings files.
+ * Not a full Groovy/Kotlin parser; falls back gracefully when layouts are unconventional.
+ */
+public final class GradleSettingsParser {
+
+    private static final Pattern INCLUDE_BLOCK = Pattern.compile(
+            "(?s)\\binclude\\s*\\(([^()]*)\\)"
+    );
+
+    private static final Pattern QUOTED_TOKEN = Pattern.compile("[\"']([^\"']+)[\"']");
+
+    private GradleSettingsParser() {
+    }
+
+    /**
+     * @return Gradle module paths relative to the settings file directory, using '/' as nested separators
+     *         (never leading '/').
+     */
+    public static List<String> parseModuleNames(Path settingsFile) throws IOException {
+        String raw = Files.readString(settingsFile, StandardCharsets.UTF_8);
+        String stripped = stripBlockComments(raw);
+        stripped = stripLineComments(stripped);
+
+        Set<String> orderedUnique = new LinkedHashSet<>();
+
+        Matcher blockMatcher = INCLUDE_BLOCK.matcher(stripped);
+        while (blockMatcher.find()) {
+            String inside = blockMatcher.group(1);
+            Matcher tokenMatcher = QUOTED_TOKEN.matcher(inside);
+            while (tokenMatcher.find()) {
+                String normalized = gradleIncludeToRelativePath(tokenMatcher.group(1));
+                if (!normalized.isEmpty()) {
+                    orderedUnique.add(normalized);
+                }
+            }
+        }
+        return List.copyOf(orderedUnique);
+    }
+
+    /** Converts Gradle path {@code :foo:bar:baz} to {@code foo/bar/baz}. */
+    static String gradleIncludeToRelativePath(String raw) {
+        if (raw == null || raw.isBlank()) {
+            return "";
+        }
+        String trimmed = raw.trim().replace('.', '/');
+        while (trimmed.startsWith(":")) {
+            trimmed = trimmed.substring(1);
+        }
+        while (trimmed.endsWith(":")) {
+            trimmed = trimmed.substring(0, trimmed.length() - 1);
+        }
+        return trimmed.replace(':', '/');
+    }
+
+    private static String stripBlockComments(String text) {
+        StringBuilder sb = new StringBuilder();
+        boolean inSlashStar = false;
+        for (int index = 0; index < text.length(); index++) {
+            char ch = text.charAt(index);
+            if (inSlashStar) {
+                if (ch == '*' && index + 1 < text.length() && text.charAt(index + 1) == '/') {
+                    inSlashStar = false;
+                    index++;
+                }
+                continue;
+            }
+            if (ch == '/' && index + 1 < text.length() && text.charAt(index + 1) == '*') {
+                inSlashStar = true;
+                index++;
+                continue;
+            }
+            sb.append(ch);
+        }
+        return sb.toString();
+    }
+
+    private static String stripLineComments(String text) {
+        StringJoiner joiner = new StringJoiner("\n");
+        for (String line : text.lines().toList()) {
+            int slashSlash = lineCommentStart(line);
+            if (slashSlash >= 0) {
+                joiner.add(line.substring(0, slashSlash));
+            } else {
+                joiner.add(line);
+            }
+        }
+        return joiner.toString();
+    }
+
+    /** Best-effort: first '//' outside of single-quoted and double-quoted segments. */
+    static int lineCommentStart(String line) {
+        boolean inDoub = false;
+        boolean inSin = false;
+        for (int index = 0; index + 1 < line.length(); index++) {
+            char prev = index > 0 ? line.charAt(index - 1) : '\0';
+            boolean escaped = prev == '\\';
+
+            char ch = line.charAt(index);
+            if (!escaped && ch == '\"') {
+                inDoub = !inDoub;
+                continue;
+            }
+            if (!escaped && !inDoub && ch == '\'') {
+                inSin = !inSin;
+                continue;
+            }
+            char next = line.charAt(index + 1);
+            if (!inSin && !inDoub && ch == '/' && next == '/') {
+                return index;
+            }
+        }
+        return -1;
+    }
+}

--- a/graphus-parser/src/main/java/io/graphus/parser/MavenModuleParser.java
+++ b/graphus-parser/src/main/java/io/graphus/parser/MavenModuleParser.java
@@ -1,0 +1,92 @@
+package io.graphus.parser;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import javax.xml.XMLConstants;
+import javax.xml.parsers.DocumentBuilderFactory;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+
+/**
+ * Extracts Maven reactor {@code module} directory names from a parent aggregator {@code pom.xml}.
+ */
+public final class MavenModuleParser {
+
+    private MavenModuleParser() {
+    }
+
+    public static List<String> parseModuleNames(Path pomFile) throws IOException {
+        try {
+            DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+            factory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
+            factory.setNamespaceAware(true);
+
+            Document document = factory.newDocumentBuilder().parse(pomFile.toFile());
+            Element root = document.getDocumentElement();
+            if (root == null) {
+                return Collections.emptyList();
+            }
+            Node modulesContainer = localChildNamed(root, "modules");
+            if (modulesContainer == null) {
+                return Collections.emptyList();
+            }
+
+            NodeList nodes = modulesContainer.getChildNodes();
+            List<String> modules = new ArrayList<>();
+            for (int index = 0; index < nodes.getLength(); index++) {
+                Node candidate = nodes.item(index);
+                if (candidate instanceof Element element && elementNameMatches(element.getLocalName(), element.getTagName(), "module")) {
+                    String text = safeTrim(element.getTextContent());
+                    if (!text.isEmpty()) {
+                        modules.add(text.replace('\\', '/'));
+                    }
+                }
+            }
+            return List.copyOf(modules);
+        } catch (Exception e) {
+            throw new IOException("Failed to parse Maven modules from " + pomFile, e);
+        }
+    }
+
+    private static boolean elementNameMatches(String localName, String tagName, String expected) {
+        if (expected.equals(localName)) {
+            return true;
+        }
+        if (tagName.equals(expected)) {
+            return true;
+        }
+        String bare = bareLocalName(tagName);
+        return expected.equalsIgnoreCase(bare);
+    }
+
+    private static Node localChildNamed(Element parent, String desired) {
+        NodeList nl = parent.getChildNodes();
+        for (int index = 0; index < nl.getLength(); index++) {
+            Node child = nl.item(index);
+            if (!(child instanceof Element element)) {
+                continue;
+            }
+            if (elementNameMatches(element.getLocalName(), element.getTagName(), desired)) {
+                return element;
+            }
+        }
+        return null;
+    }
+
+    private static String bareLocalName(String tagName) {
+        int colonIndex = tagName.indexOf(':');
+        if (colonIndex == -1) {
+            return tagName;
+        }
+        return tagName.substring(colonIndex + 1);
+    }
+
+    private static String safeTrim(String raw) {
+        return raw == null ? "" : raw.trim();
+    }
+}

--- a/graphus-parser/src/main/java/io/graphus/parser/ProjectParser.java
+++ b/graphus-parser/src/main/java/io/graphus/parser/ProjectParser.java
@@ -8,6 +8,8 @@ import com.github.javaparser.symbolsolver.resolution.typesolvers.CombinedTypeSol
 import com.github.javaparser.symbolsolver.resolution.typesolvers.JavaParserTypeSolver;
 import com.github.javaparser.symbolsolver.resolution.typesolvers.ReflectionTypeSolver;
 import io.graphus.model.CallGraph;
+import io.graphus.model.ModuleDescriptor;
+import io.graphus.model.WorkspaceDescriptor;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -58,6 +60,25 @@ public final class ProjectParser {
         CallGraphBuilder callGraphBuilder = new CallGraphBuilder(repositoryRoot.toAbsolutePath().normalize());
         int unresolvedCalls = callGraphBuilder.buildEdges(callGraph, parserContext.callableIdsByDeclaration());
         return new ProjectParserResult(callGraph, parsedFiles, unresolvedCalls);
+    }
+
+    public ProjectParserResult parse(WorkspaceDescriptor workspace) throws IOException {
+        return parse(workspace, (path, index, total) -> {});
+    }
+
+    public ProjectParserResult parse(WorkspaceDescriptor workspace, ParseProgressListener progressListener)
+            throws IOException {
+        Path repositoryRoot = workspace.root();
+        List<Path> normalizedRoots = new ArrayList<>();
+        for (ModuleDescriptor moduleDescriptor : workspace.modules()) {
+            for (Path sourceRootFromModule : moduleDescriptor.sourceRoots()) {
+                Path absolute = sourceRootFromModule.toAbsolutePath().normalize();
+                if (!normalizedRoots.contains(absolute)) {
+                    normalizedRoots.add(absolute);
+                }
+            }
+        }
+        return parse(repositoryRoot, normalizedRoots, progressListener);
     }
 
     private ParserConfiguration createParserConfiguration(List<Path> sourceRoots) {

--- a/graphus-parser/src/main/java/io/graphus/parser/RepositoryLayoutDetector.java
+++ b/graphus-parser/src/main/java/io/graphus/parser/RepositoryLayoutDetector.java
@@ -1,0 +1,197 @@
+package io.graphus.parser;
+
+import io.graphus.model.ModuleDescriptor;
+import io.graphus.model.WorkspaceDescriptor;
+import java.io.IOException;
+import java.nio.file.DirectoryStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Set;
+
+/**
+ * Determines how Java sources are laid out under a repository directory.
+ */
+public final class RepositoryLayoutDetector {
+
+    private static final Set<String> EXCLUDED_DIRECTORIES = Set.of(
+            "build",
+            "target",
+            "out",
+            "dist",
+            "node_modules",
+            ".gradle",
+            ".idea",
+            ".git");
+
+    private RepositoryLayoutDetector() {
+    }
+
+    /**
+     * Produces zero or more {@link WorkspaceDescriptor} entries to index independently.
+     *
+     * @param root filesystem root supplied by CLI {@code --repo}
+     */
+    public static List<WorkspaceDescriptor> detect(Path root) throws IOException {
+        return detectRecursive(root.toAbsolutePath().normalize(), 0);
+    }
+
+    private static List<WorkspaceDescriptor> detectRecursive(Path resolvedRoot, int depth) throws IOException {
+        if (depth > 2) {
+            return List.of();
+        }
+
+        if (Files.isDirectory(resolvedRoot.resolve("src/main/java"))) {
+            return List.of(createSingle(resolvedRoot));
+        }
+
+        Path settingsKts = resolvedRoot.resolve("settings.gradle.kts");
+        Path settingsGroovy = resolvedRoot.resolve("settings.gradle");
+        Path settingsFile = Files.exists(settingsKts) ? settingsKts : (Files.exists(settingsGroovy) ? settingsGroovy : null);
+        if (settingsFile != null) {
+            return List.of(buildGradleWorkspace(resolvedRoot, settingsFile));
+        }
+
+        Path pom = resolvedRoot.resolve("pom.xml");
+        if (Files.exists(pom)) {
+            List<String> mavenModules = MavenModuleParser.parseModuleNames(pom);
+            if (!mavenModules.isEmpty()) {
+                return List.of(buildMavenWorkspace(resolvedRoot, mavenModules));
+            }
+        }
+
+        if (depth > 0) {
+            System.err.println(
+                    "WARN: skipping path with no recognizable Java workspace layout — " + resolvedRoot);
+            return List.of();
+        }
+
+        return detectParentWorkspace(resolvedRoot);
+    }
+
+    private static List<WorkspaceDescriptor> detectParentWorkspace(Path parentRoot) throws IOException {
+        List<WorkspaceDescriptor> collected = new ArrayList<>();
+        try (DirectoryStream<Path> stream = Files.newDirectoryStream(parentRoot, Files::isDirectory)) {
+            List<Path> children = new ArrayList<>();
+            for (Path entry : stream) {
+                children.add(entry);
+            }
+            children.sort(Comparator.comparing(a -> a.getFileName().toString()));
+
+            for (Path child : children) {
+                String leaf = child.getFileName().toString();
+                if (leaf.startsWith(".") || EXCLUDED_DIRECTORIES.contains(leaf.toLowerCase(Locale.ROOT))) {
+                    continue;
+                }
+                collected.addAll(detectRecursive(child.toAbsolutePath().normalize(), 1));
+            }
+        }
+        return Collections.unmodifiableList(collected);
+    }
+
+    private static WorkspaceDescriptor createSingle(Path root) throws IOException {
+        String name = root.getFileName().toString();
+        Path javaRoot = root.resolve("src/main/java").toAbsolutePath().normalize();
+        ModuleDescriptor module = new ModuleDescriptor(name, root, List.of(javaRoot));
+        return new WorkspaceDescriptor(name, root, List.of(module));
+    }
+
+    private static WorkspaceDescriptor buildGradleWorkspace(Path repoRoot, Path settingsFile)
+            throws IOException {
+        LinkedHashSet<String> moduleIncludes = new LinkedHashSet<>(GradleSettingsParser.parseModuleNames(settingsFile));
+        if (moduleIncludes.isEmpty()) {
+            moduleIncludes.addAll(scanModuleDirectories(repoRoot));
+        }
+        List<ModuleDescriptor> descriptors = descriptorsForRelativePaths(repoRoot, moduleIncludes);
+        if (descriptors.isEmpty()) {
+            return createSingle(repoRoot);
+        }
+        String name = repoRoot.getFileName().toString();
+        return new WorkspaceDescriptor(name, repoRoot, descriptors);
+    }
+
+    private static WorkspaceDescriptor buildMavenWorkspace(Path repoRoot, List<String> modulePaths)
+            throws IOException {
+        LinkedHashSet<String> uniqueModules = new LinkedHashSet<>(modulePaths);
+        List<ModuleDescriptor> descriptors = descriptorsForRelativePaths(repoRoot, uniqueModules);
+        if (descriptors.isEmpty()) {
+            return createSingle(repoRoot);
+        }
+        String name = repoRoot.getFileName().toString();
+        return new WorkspaceDescriptor(name, repoRoot, descriptors);
+    }
+
+    private static List<ModuleDescriptor> descriptorsForRelativePaths(Path workspaceRoot,
+            Iterable<String> relativeModuleDirectories) throws IOException {
+        List<ModuleDescriptor> descriptors = new ArrayList<>();
+        for (String relative : relativeModuleDirectories) {
+            if (relative == null || relative.isBlank()) {
+                continue;
+            }
+            String normalizedSegments = normalizeRelativeSegments(relative);
+            Path moduleRootCandidate = workspaceRoot.resolve(normalizedSegments).normalize();
+            if (!Files.isDirectory(moduleRootCandidate)) {
+                continue;
+            }
+            if (!moduleRootCandidate.startsWith(workspaceRoot)) {
+                continue;
+            }
+            Path javaRootPath = moduleRootCandidate.resolve("src/main/java").toAbsolutePath().normalize();
+
+            descriptors.add(new ModuleDescriptor(
+                    tagNameFromGradlePath(normalizedSegments),
+                    moduleRootCandidate.toAbsolutePath().normalize(),
+                    List.of(javaRootPath))
+            );
+        }
+        return descriptors;
+    }
+
+    /** Scans immediate child directories exposing {@code src/main/java}. */
+    private static List<String> scanModuleDirectories(Path workspaceRoot) throws IOException {
+        LinkedHashSet<String> discovered = new LinkedHashSet<>();
+
+        List<Path> directChildren = new ArrayList<>();
+        try (DirectoryStream<Path> ds = Files.newDirectoryStream(workspaceRoot, Files::isDirectory)) {
+            for (Path p : ds) {
+                directChildren.add(p.toAbsolutePath().normalize());
+            }
+        }
+
+        Comparator<Path> byName =
+                Comparator.comparing(a -> a.getFileName().toString());
+
+        Collections.sort(directChildren, byName);
+
+        for (Path childAbs : directChildren) {
+            String leaf = childAbs.getFileName().toString();
+            if (leaf.startsWith(".") || EXCLUDED_DIRECTORIES.contains(leaf.toLowerCase(Locale.ROOT))) {
+                continue;
+            }
+
+            Path javaHere = childAbs.resolve("src/main/java");
+            if (Files.isDirectory(javaHere)) {
+                Path relativized = workspaceRoot.relativize(childAbs.normalize());
+                String textual = relativized.toString().replace('\\', '/');
+                if (!textual.isBlank()) {
+                    discovered.add(normalizeRelativeSegments(textual));
+                }
+            }
+        }
+
+        return List.copyOf(discovered);
+    }
+
+    private static String normalizeRelativeSegments(String path) {
+        return path.stripLeading().replace('\\', '/');
+    }
+
+    private static String tagNameFromGradlePath(String pathWithSlashes) {
+        return normalizeRelativeSegments(pathWithSlashes).replace("/", "__");
+    }
+}

--- a/graphus-parser/src/test/java/io/graphus/parser/GradleSettingsParserTest.java
+++ b/graphus-parser/src/test/java/io/graphus/parser/GradleSettingsParserTest.java
@@ -1,0 +1,46 @@
+package io.graphus.parser;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class GradleSettingsParserTest {
+
+    @Test
+    void parsesKotlinIncludes(@TempDir Path tempDir) throws IOException {
+        Path file = tempDir.resolve("settings.gradle.kts");
+        Files.writeString(file, """
+                rootProject.name = "demo"
+                include("core", "api")
+                """);
+        assertEquals(
+                List.of("core", "api"),
+                GradleSettingsParser.parseModuleNames(file));
+    }
+
+    @Test
+    void colonNestedPathsBecomeSlashes(@TempDir Path tempDir) throws IOException {
+        Path file = tempDir.resolve("settings.gradle.kts");
+        Files.writeString(file, """
+                include(":services:payments")
+                """);
+        assertEquals(
+                List.of("services/payments"),
+                GradleSettingsParser.parseModuleNames(file));
+    }
+
+    @Test
+    void lineCommentStartSkipsQuotedDoubleSlash() {
+        assertEquals(2, GradleSettingsParser.lineCommentStart("x // y"));
+        assertEquals(-1, GradleSettingsParser.lineCommentStart("println(\"a//b\");"));
+        String lineWithTrailingComment = "println(\"ok\"); // tail";
+        assertEquals(
+                lineWithTrailingComment.indexOf("//"),
+                GradleSettingsParser.lineCommentStart(lineWithTrailingComment));
+    }
+}

--- a/graphus-parser/src/test/java/io/graphus/parser/MavenModuleParserTest.java
+++ b/graphus-parser/src/test/java/io/graphus/parser/MavenModuleParserTest.java
@@ -1,0 +1,33 @@
+package io.graphus.parser;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class MavenModuleParserTest {
+
+    @Test
+    void readsModuleElements(@TempDir Path tempDir) throws IOException {
+        Path pom = tempDir.resolve("pom.xml");
+        Files.writeString(pom, """
+                <project>
+                  <modelVersion>4.0.0</modelVersion>
+                  <groupId>demo</groupId>
+                  <artifactId>parent</artifactId>
+                  <version>1-SNAPSHOT</version>
+                  <packaging>pom</packaging>
+                  <modules>
+                    <module> core </module>
+                    <module>api</module>
+                  </modules>
+                </project>
+                """);
+
+        assertEquals(List.of("core", "api"), MavenModuleParser.parseModuleNames(pom));
+    }
+}

--- a/graphus-parser/src/test/java/io/graphus/parser/RepositoryLayoutDetectorTest.java
+++ b/graphus-parser/src/test/java/io/graphus/parser/RepositoryLayoutDetectorTest.java
@@ -1,0 +1,114 @@
+package io.graphus.parser;
+
+import io.graphus.model.ModuleDescriptor;
+import io.graphus.model.WorkspaceDescriptor;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class RepositoryLayoutDetectorTest {
+
+    @Test
+    void detectsGradleMultiModuleLayout(@TempDir Path tempDir) throws Exception {
+        Path root = tempDir.resolve("mono");
+        Files.createDirectories(root);
+        Files.writeString(root.resolve("settings.gradle.kts"), "include(\"core\", \"api\")\n");
+
+        Files.createDirectories(root.resolve("core/src/main/java"));
+        Files.createDirectories(root.resolve("api/src/main/java"));
+
+        List<WorkspaceDescriptor> workspaces = RepositoryLayoutDetector.detect(root);
+        assertEquals(1, workspaces.size());
+
+        WorkspaceDescriptor workspace = workspaces.get(0);
+        assertTrue(workspace.isMultiModule());
+        assertEquals("mono", workspace.name());
+
+        Map<String, ModuleDescriptor> byName = workspace.modules().stream()
+                .collect(Collectors.toMap(ModuleDescriptor::name, Function.identity()));
+
+        assertEquals(2, byName.size());
+        assertEquals(
+                root.resolve("core/src/main/java").toAbsolutePath().normalize(),
+                byName.get("core").sourceRoots().get(0));
+        assertEquals(
+                root.resolve("api/src/main/java").toAbsolutePath().normalize(),
+                byName.get("api").sourceRoots().get(0));
+    }
+
+    @Test
+    void detectsMavenMultiModuleParent(@TempDir Path tempDir) throws Exception {
+        Path root = tempDir.resolve("maven-parent");
+        Files.createDirectories(root);
+        Files.writeString(
+                root.resolve("pom.xml"),
+                """
+                        <project>
+                          <modelVersion>4.0.0</modelVersion>
+                          <groupId>t</groupId>
+                          <artifactId>p</artifactId>
+                          <version>1-SNAPSHOT</version>
+                          <packaging>pom</packaging>
+                          <modules>
+                            <module>alpha</module>
+                            <module>beta</module>
+                          </modules>
+                        </project>
+                        """);
+
+        Files.createDirectories(root.resolve("alpha/src/main/java"));
+        Files.createDirectories(root.resolve("beta/src/main/java"));
+
+        WorkspaceDescriptor ws = RepositoryLayoutDetector.detect(root).get(0);
+        assertTrue(ws.isMultiModule());
+        assertEquals(2, ws.modules().size());
+    }
+
+    @Test
+    void singleModuleWhenSrcExistsAtRoot(@TempDir Path tempDir) throws Exception {
+        Path app = tempDir.resolve("app");
+        Files.createDirectories(app.resolve("src/main/java"));
+        WorkspaceDescriptor ws = RepositoryLayoutDetector.detect(app).get(0);
+        assertFalse(ws.isMultiModule());
+        assertEquals(app.getFileName().toString(), ws.name());
+    }
+
+    @Test
+    void parentWorkspaceReturnsChildWorkspaces(@TempDir Path tempDir) throws Exception {
+        Path workspace = tempDir.resolve("workspace");
+        Files.createDirectories(workspace);
+
+        Path projectA = workspace.resolve("project-a");
+        Files.createDirectories(projectA.resolve("src/main/java"));
+
+        Path projectB = workspace.resolve("project-b");
+        Files.createDirectories(projectB);
+        Files.writeString(projectB.resolve("settings.gradle.kts"), "include(\"core\", \"api\")\n");
+        Files.createDirectories(projectB.resolve("core/src/main/java"));
+        Files.createDirectories(projectB.resolve("api/src/main/java"));
+
+        List<WorkspaceDescriptor> list = RepositoryLayoutDetector.detect(workspace);
+        assertEquals(2, list.size());
+
+        WorkspaceDescriptor wsA =
+                list.stream().filter(workspaceDescriptor -> "project-a".equals(workspaceDescriptor.name()))
+                        .findFirst()
+                        .orElseThrow();
+        assertFalse(wsA.isMultiModule());
+
+        WorkspaceDescriptor wsB =
+                list.stream().filter(workspaceDescriptor -> "project-b".equals(workspaceDescriptor.name()))
+                        .findFirst()
+                        .orElseThrow();
+        assertTrue(wsB.isMultiModule());
+    }
+}


### PR DESCRIPTION
## Summary

- Add Gradle/Maven multi-module workspace detection; index symbol chunks into one collection with module metadata tags and indexer/query/filter support aligned with incremental sync semantics.
- Update CLI flows for index, sync, query (including `--module`), and blast-radius for multi-workspace resolution.
- Add `graphus-cli/.gitignore` to exclude local `.graphus/` checksum/index state.

## Test plan

- [x] `./gradlew test`
- [x] `./gradlew clean build`

Related to #32