### PR TITLE
feat(cli): add index benchmark JSON and release PERFORMANCE artifact

### DIFF
--- a/.github/performance-repos.json
+++ b/.github/performance-repos.json
@@ -1,0 +1,23 @@
+{
+  "schemaVersion": 1,
+  "repos": [
+    {
+      "tier": "small",
+      "slug": "spring-guides/gs-rest-service",
+      "ref": "e9efc9dfa0abe8cf8e15cf0e71830b5125322cae",
+      "note": "Pinned commit on main (Spring getting-started sample; single-module)"
+    },
+    {
+      "tier": "medium",
+      "slug": "spring-io/initializr",
+      "ref": "v0.22.0",
+      "note": "Multi-module Initializr codebase"
+    },
+    {
+      "tier": "large",
+      "slug": "spring-projects/spring-boot",
+      "ref": "v3.4.2",
+      "note": "Large Spring Boot repo; shallow clone"
+    }
+  ]
+}

--- a/.github/scripts/generate-performance-report.sh
+++ b/.github/scripts/generate-performance-report.sh
@@ -1,0 +1,126 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Generates PERFORMANCE.md from graphus index --benchmark-json runs.
+# Env: GRAPHUS_JAR, CHROMA_URL, RELEASE_TAG, RUNNER_OS, CHROMA_IMAGE, REPOS_JSON, OUT_MD
+
+GRAPHUS_JAR="${GRAPHUS_JAR:?GRAPHUS_JAR required}"
+CHROMA_URL="${CHROMA_URL:?CHROMA_URL required}"
+RELEASE_TAG="${RELEASE_TAG:?RELEASE_TAG required}"
+RUNNER_OS="${RUNNER_OS:-unknown}"
+CHROMA_IMAGE="${CHROMA_IMAGE:-chromadb/chroma:1.1.0}"
+REPOS_JSON="${REPOS_JSON:?REPOS_JSON required}"
+OUT_MD="${OUT_MD:?OUT_MD required}"
+WORKDIR="${WORKDIR:-${RUNNER_TEMP:-/tmp}/graphus-perf}"
+
+mkdir -p "${WORKDIR}"
+
+clone_repo() {
+  local slug="$1"
+  local ref="$2"
+  local dest="$3"
+  rm -rf "${dest}"
+  if [[ "${ref}" =~ ^[0-9a-f]{40}$ ]]; then
+    mkdir -p "${dest}"
+    git -C "${dest}" init -q
+    git -C "${dest}" remote add origin "https://github.com/${slug}.git"
+    git -C "${dest}" fetch --depth 1 origin "${ref}"
+    git -C "${dest}" checkout -q FETCH_HEAD
+  else
+    git clone --branch "${ref}" --depth 1 "https://github.com/${slug}.git" "${dest}"
+  fi
+}
+
+UTC_NOW="$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
+SAFE_TAG="$(echo "${RELEASE_TAG}" | tr -c 'a-zA-Z0-9_' '_')"
+
+{
+  echo "# Graphus indexing performance"
+  echo ""
+  echo "Automated benchmark attached to GitHub Release **${RELEASE_TAG}**."
+  echo ""
+  echo "## Environment"
+  echo ""
+  echo "| Field | Value |"
+  echo "| --- | --- |"
+  echo "| Generated (UTC) | ${UTC_NOW} |"
+  echo "| Runner | ${RUNNER_OS} |"
+  echo "| Chroma image | ${CHROMA_IMAGE} |"
+  echo "| Chroma URL (in job) | ${CHROMA_URL} |"
+  echo "| Embedding | local (ONNX MiniLM; cold CI runs may download weights unless cached) |"
+  echo ""
+  echo "Tiers are named fixture repos at pinned refs (manifest: \`.github/performance-repos.json\`). Compare trends across releases; single CI runs vary."
+  echo ""
+  echo "## Results"
+  echo ""
+  echo "| Tier | Repo @ ref | Workspace | Clear | Parse | Index | Checksum | Sum phases | Parsed files | Indexed symbols |"
+  echo "| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |"
+} >"${OUT_MD}"
+
+append_workspace_rows() {
+  local tier="$1"
+  local slug="$2"
+  local ref="$3"
+  local json="$4"
+
+  jq -r --arg slug "${slug}" --arg ref "${ref}" --arg tier "${tier}" '
+    .workspaces[] |
+    [
+      $tier,
+      ($slug + " @ " + $ref),
+      .workspaceName,
+      (.clearNanos / 1000000000),
+      (.parseNanos / 1000000000),
+      (.indexNanos / 1000000000),
+      (.checksumNanos / 1000000000),
+      ((.clearNanos + .parseNanos + .indexNanos + .checksumNanos) / 1000000000),
+      .parsedFiles,
+      .indexedSymbols
+    ] | @tsv
+  ' "${json}" | while IFS=$'\t' read -r c0 c1 c2 c3 c4 c5 c6 c7 c8 c9; do
+    printf '| %s | %s | %s | %.2fs | %.2fs | %.2fs | %.2fs | %.2fs | %s | %s |\n' \
+      "${c0}" "${c1}" "${c2}" "${c3}" "${c4}" "${c5}" "${c6}" "${c7}" "${c8}" "${c9}" >>"${OUT_MD}"
+  done
+}
+
+while IFS=$'\t' read -r tier slug ref; do
+  [[ -z "${tier}" ]] && continue
+  dest="${WORKDIR}/clone-${tier}"
+  json="${WORKDIR}/bench-${tier}.json"
+  clone_repo "${slug}" "${ref}" "${dest}"
+
+  collection="perf_${tier}_${SAFE_TAG}"
+
+  java -jar "${GRAPHUS_JAR}" index \
+    --repo "${dest}" \
+    --db chroma \
+    --db-url "${CHROMA_URL}" \
+    --embedding local \
+    --collection "${collection}" \
+    --state-dir "${WORKDIR}/state-${tier}" \
+    --benchmark-json "${json}"
+
+  append_workspace_rows "${tier}" "${slug}" "${ref}" "${json}"
+
+done < <(jq -r '.repos[] | "\(.tier)\t\(.slug)\t\(.ref)"' "${REPOS_JSON}")
+
+{
+  echo ""
+  echo "**Sum phases** is clear+parse+index+checksum for that workspace row. Global wall clock per tier JSON includes \`totalWallNanos\` (full JVM run)."
+  echo ""
+  echo "## Raw JSON (per tier)"
+  echo ""
+} >>"${OUT_MD}"
+
+while IFS=$'\t' read -r tier slug ref; do
+  [[ -z "${tier}" ]] && continue
+  json="${WORKDIR}/bench-${tier}.json"
+  {
+    echo "### ${tier}: ${slug} @ ${ref}"
+    echo ""
+    echo '```json'
+    cat "${json}"
+    echo '```'
+    echo ""
+  } >>"${OUT_MD}"
+done < <(jq -r '.repos[] | "\(.tier)\t\(.slug)\t\(.ref)"' "${REPOS_JSON}")

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -99,3 +99,74 @@ jobs:
               --add-label "released" \
               --repo "${{ github.repository }}"
           done
+
+  benchmark:
+    name: Performance report
+    needs: publish
+    runs-on: ubuntu-latest
+    timeout-minutes: 180
+    services:
+      chroma:
+        image: chromadb/chroma:1.1.0
+        ports:
+          - 8000:8000
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: "21"
+
+      - name: Cache embedding and model downloads
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache
+          key: ${{ runner.os }}-graphus-perf-${{ hashFiles('.github/workflows/publish.yml', '.github/performance-repos.json') }}
+          restore-keys: |
+            ${{ runner.os }}-graphus-perf-
+
+      - name: Wait for Chroma
+        env:
+          CHROMA_URL: http://chroma:8000
+        run: |
+          set -e
+          for _ in $(seq 1 90); do
+            if curl -sf "${CHROMA_URL}/api/v1/heartbeat" >/dev/null 2>&1 \
+              || curl -sf "${CHROMA_URL}/api/v2/heartbeat" >/dev/null 2>&1; then
+              echo "Chroma ready"
+              exit 0
+            fi
+            sleep 2
+          done
+          echo "Chroma did not become ready in time"
+          exit 1
+
+      - name: Download released graphus.jar
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release download "${{ github.event.release.tag_name }}" \
+            --repo "${{ github.repository }}" \
+            --pattern graphus.jar \
+            --dir "${{ github.workspace }}" \
+            --clobber
+
+      - name: Generate PERFORMANCE.md and upload
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GRAPHUS_JAR: ${{ github.workspace }}/graphus.jar
+          CHROMA_URL: http://chroma:8000
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+          RUNNER_OS: ${{ runner.os }}-${{ runner.arch }}
+          CHROMA_IMAGE: chromadb/chroma:1.1.0
+          REPOS_JSON: ${{ github.workspace }}/.github/performance-repos.json
+          OUT_MD: /tmp/PERFORMANCE.md
+        run: |
+          bash "${{ github.workspace }}/.github/scripts/generate-performance-report.sh"
+          gh release upload "${{ github.event.release.tag_name }}" /tmp/PERFORMANCE.md \
+            --repo "${{ github.repository }}" \
+            --clobber

--- a/PERFORMANCE.md
+++ b/PERFORMANCE.md
@@ -1,0 +1,39 @@
+# Performance benchmarking methodology
+
+Graphus publishes **automated indexing benchmarks** as a **`PERFORMANCE.md`** asset on each [GitHub Release](https://github.com/alcantaraleo/graphus/releases). This file explains how those numbers are produced; **it does not store current timings** (those live only on Releases).
+
+## What is measured
+
+For each pinned tier, CI runs the released fat JAR with:
+
+```text
+java -jar graphus.jar index \
+  --repo <cloned fixture> \
+  --db chroma \
+  --db-url http://chroma:8000 \
+  --embedding local \
+  --collection perf_<tier>_<tag> \
+  --benchmark-json <path>
+```
+
+Phases recorded per workspace (nanoseconds in JSON; seconds rounded in the release table):
+
+- **Clear** — empty the Chroma collection
+- **Parse** — AST / call-graph build
+- **Index** — chunking, embeddings, Chroma upsert
+- **Checksum** — `checksums.json` registry
+
+## Fixture tiers (“small”, “medium”, “large”)
+
+Tiers are **not** LOC bands. Each tier is a **named corpus** in [`.github/performance-repos.json`](.github/performance-repos.json), pinned to a **git tag or SHA** so runs are repeatable. Cold CI workers may spend extra time on first **local embedding** downloads unless caches hit—compare trends across releases, not single runs.
+
+Multi-module layouts may produce **multiple workspace rows** per tier; see the Workspace column.
+
+## Workflow policy
+
+- **Publish vs benchmark:** Assets (`graphus.jar`, etc.) are uploaded in the `publish` job first. **`benchmark`** runs afterward and uploads `PERFORMANCE.md`. If the benchmark job fails, that job fails visibly (artifacts are already published).
+- Structured output uses **`--benchmark-json`** — there is no log-scraping fallback.
+
+## Local reproduction
+
+Run Chroma (e.g. `docker compose up -d`), check out fixtures at the same refs as [.github/performance-repos.json](.github/performance-repos.json), then run `graphus index` with `--benchmark-json` as CI does.

--- a/README.md
+++ b/README.md
@@ -73,6 +73,10 @@ Run tests only:
 ./gradlew test
 ```
 
+## Performance benchmarks
+
+Timing results for full `graphus index` runs against pinned fixture repos (small / medium / large) ship as **`PERFORMANCE.md`** on each [GitHub Release](https://github.com/alcantaraleo/graphus/releases)—CI generates and uploads it when a release is published. For methodology (tiers, refs, caveats only), see [PERFORMANCE.md](PERFORMANCE.md).
+
 ## CLI Usage
 
 ### Index a Repository (Full Rebuild)
@@ -100,6 +104,7 @@ graphus index \
 | `--batch-size`   | `500`                   | Symbols per embedding/index batch                                                                                            |
 | `--embedding`    | persisted or `local`    | Embedding backend: `local` \| `openai`                                                                                         |
 | `--state-dir`    | `{repo}/.graphus`       | Directory where `checksums.json`, `config.json`, and optionally `graphus.db` live                                             |
+| `--benchmark-json` | _(unset)_             | Write phase timings + counts as JSON |
 
 ### Sync (Incremental Update)
 

--- a/graphus-cli/src/main/java/io/graphus/cli/GraphusCommand.java
+++ b/graphus-cli/src/main/java/io/graphus/cli/GraphusCommand.java
@@ -19,6 +19,7 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.time.Duration;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.LinkedHashMap;
@@ -93,6 +94,11 @@ public final class GraphusCommand implements Callable<Integer> {
         @Option(names = "--state-dir", description = "Directory where checksums.json is stored (default: .graphus per workspace)")
         private Path stateDir;
 
+        @Option(
+                names = "--benchmark-json",
+                description = "Write structured index phase timings and counts to this file (JSON)")
+        private Path benchmarkJson;
+
         @Override
         public Integer call() throws Exception {
             long totalStartNanos = System.nanoTime();
@@ -102,6 +108,8 @@ public final class GraphusCommand implements Callable<Integer> {
             int totalParsed = 0;
             int totalUnresolved = 0;
             int indexedSymbolsAccumulator = 0;
+            List<IndexBenchmarkReport.WorkspaceEntry> benchmarkWorkspaces =
+                    benchmarkJson != null ? new ArrayList<>() : Collections.emptyList();
 
             ProjectParser projectParser = new ProjectParser();
 
@@ -134,32 +142,51 @@ public final class GraphusCommand implements Callable<Integer> {
                 System.out.println(phase("Clearing existing index..."));
                 long clearStartNanos = System.nanoTime();
                 graphIndexer.removeAll();
-                System.out.println(timing("Clear time      : ", formatElapsed(clearStartNanos)));
+                long clearNanos = nanosSince(clearStartNanos);
+                System.out.println(timing("Clear time      : ", formatDurationNanos(clearNanos)));
 
                 long parseStartNanos = System.nanoTime();
                 ParserProgressReporter reporter = new ParserProgressReporter();
                 ProjectParserResult parseResult = projectParser.parse(workspace, reporter);
                 reporter.complete();
-                System.out.println(timing("Parse time      : ", formatElapsed(parseStartNanos)));
+                long parseNanos = nanosSince(parseStartNanos);
+                System.out.println(timing("Parse time      : ", formatDurationNanos(parseNanos)));
 
                 long indexStartNanos = System.nanoTime();
                 IndexProgressReporter indexReporter = new IndexProgressReporter();
-                indexedSymbolsAccumulator += graphIndexer.index(parseResult.callGraph(), workspace, indexReporter);
+                int indexedThisWorkspace =
+                        graphIndexer.index(parseResult.callGraph(), workspace, indexReporter);
+                indexedSymbolsAccumulator += indexedThisWorkspace;
                 indexReporter.complete();
-                System.out.println(timing("Index time      : ", formatElapsed(indexStartNanos)));
+                long indexNanos = nanosSince(indexStartNanos);
+                System.out.println(timing("Index time      : ", formatDurationNanos(indexNanos)));
 
                 System.out.println(phase("Saving checksum registry..."));
                 long checksumStartNanos = System.nanoTime();
                 FileChecksumRegistry registry = FileChecksumRegistry.empty();
                 registry.recomputeAll(workspace.root(), normalizedRoots);
                 registry.save(resolvedStateDir);
-                System.out.println(timing("Checksum time   : ", formatElapsed(checksumStartNanos)));
+                long checksumNanos = nanosSince(checksumStartNanos);
+                System.out.println(timing("Checksum time   : ", formatDurationNanos(checksumNanos)));
 
                 GraphusConfigRegistry.save(
                         resolvedStateDir, GraphusVectorRuntime.persistableCopy(resolvedCollection, runtime));
 
                 totalParsed += parseResult.parsedFiles();
                 totalUnresolved += parseResult.unresolvedCalls();
+
+                if (benchmarkJson != null) {
+                    benchmarkWorkspaces.add(new IndexBenchmarkReport.WorkspaceEntry(
+                            workspace.name(),
+                            resolvedCollection,
+                            clearNanos,
+                            parseNanos,
+                            indexNanos,
+                            checksumNanos,
+                            parseResult.parsedFiles(),
+                            parseResult.unresolvedCalls(),
+                            indexedThisWorkspace));
+                }
 
                 System.out.println(summary(
                         "Registry saved  : ", resolvedStateDir.resolve("checksums.json").toString()));
@@ -174,6 +201,19 @@ public final class GraphusCommand implements Callable<Integer> {
                     "Indexed symbols : ",
                     Integer.toString(indexedSymbolsAccumulator)));
             System.out.println(summary("Total time      : ", formatElapsed(totalStartNanos)));
+
+            if (benchmarkJson != null) {
+                IndexBenchmarkReport.write(
+                        benchmarkJson.toAbsolutePath().normalize(),
+                        new IndexBenchmarkReport.Payload(
+                                1,
+                                "index",
+                                nanosSince(totalStartNanos),
+                                totalParsed,
+                                totalUnresolved,
+                                indexedSymbolsAccumulator,
+                                benchmarkWorkspaces));
+            }
             return 0;
         }
     }
@@ -556,8 +596,16 @@ public final class GraphusCommand implements Callable<Integer> {
         return fallback;
     }
 
+    private static long nanosSince(long startNanos) {
+        return System.nanoTime() - startNanos;
+    }
+
+    private static String formatDurationNanos(long nanos) {
+        return formatDuration(Duration.ofNanos(Math.max(0L, nanos)));
+    }
+
     private static String formatElapsed(long startNanos) {
-        return formatDuration(Duration.ofNanos(System.nanoTime() - startNanos));
+        return formatDurationNanos(nanosSince(startNanos));
     }
 
     private static String phase(String value) {

--- a/graphus-cli/src/main/java/io/graphus/cli/IndexBenchmarkReport.java
+++ b/graphus-cli/src/main/java/io/graphus/cli/IndexBenchmarkReport.java
@@ -1,0 +1,53 @@
+package io.graphus.cli;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Machine-readable timings for {@code graphus index}, written when {@code --benchmark-json} is set.
+ */
+public final class IndexBenchmarkReport {
+
+    private static final ObjectMapper MAPPER = new ObjectMapper()
+            .enable(SerializationFeature.INDENT_OUTPUT);
+
+    public record WorkspaceEntry(
+            String workspaceName,
+            String collection,
+            long clearNanos,
+            long parseNanos,
+            long indexNanos,
+            long checksumNanos,
+            int parsedFiles,
+            int unresolvedCalls,
+            int indexedSymbols) {}
+
+    public record Payload(
+            int schemaVersion,
+            String command,
+            long totalWallNanos,
+            int totalParsedFiles,
+            int totalUnresolvedCalls,
+            int totalIndexedSymbols,
+            List<WorkspaceEntry> workspaces) {}
+
+    public static void write(Path path, Payload payload) throws IOException {
+        Objects.requireNonNull(path, "path");
+        Objects.requireNonNull(payload, "payload");
+        Path parent = path.getParent();
+        if (parent != null) {
+            Files.createDirectories(parent);
+        }
+        try (OutputStream out = Files.newOutputStream(path)) {
+            MAPPER.writeValue(out, payload);
+        }
+    }
+
+    private IndexBenchmarkReport() {}
+}

--- a/graphus-cli/src/test/java/io/graphus/cli/IndexBenchmarkReportTest.java
+++ b/graphus-cli/src/test/java/io/graphus/cli/IndexBenchmarkReportTest.java
@@ -1,0 +1,55 @@
+package io.graphus.cli;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class IndexBenchmarkReportTest {
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    @Test
+    void writeProducesExpectedShape(@TempDir Path dir) throws Exception {
+        Path out = dir.resolve("bench.json");
+        IndexBenchmarkReport.write(
+                out,
+                new IndexBenchmarkReport.Payload(
+                        1,
+                        "index",
+                        99L,
+                        10,
+                        2,
+                        40,
+                        List.of(new IndexBenchmarkReport.WorkspaceEntry(
+                                "ws1",
+                                "coll-a",
+                                1L,
+                                2L,
+                                3L,
+                                4L,
+                                5,
+                                1,
+                                40))));
+
+        assertTrue(Files.exists(out));
+        JsonNode root = MAPPER.readTree(out.toFile());
+        assertEquals(1, root.path("schemaVersion").asInt());
+        assertEquals("index", root.path("command").asText());
+        assertEquals(99L, root.path("totalWallNanos").asLong());
+        assertEquals(10, root.path("totalParsedFiles").asInt());
+        assertEquals(2, root.path("totalUnresolvedCalls").asInt());
+        assertEquals(40, root.path("totalIndexedSymbols").asInt());
+        JsonNode ws = root.path("workspaces").get(0);
+        assertEquals("ws1", ws.path("workspaceName").asText());
+        assertEquals("coll-a", ws.path("collection").asText());
+        assertEquals(4L, ws.path("checksumNanos").asLong());
+        assertEquals(40, ws.path("indexedSymbols").asInt());
+    }
+}


### PR DESCRIPTION
## Summary

- Add `--benchmark-json` on `index` writing schemaVersion 1 phase timings and counts (plus `IndexBenchmarkReport` + tests).
- Extend `publish.yml` with a post-release `benchmark` job: Chroma service, fixture manifest, harness script, attach `PERFORMANCE.md` to the release.
- Add `PERFORMANCE.md` methodology stub and README section pointing to release assets for numbers.

## Test plan

- [x] `./gradlew test`

Related to #35