### PR TITLE
fix(deps): resolve open Dependabot security alerts

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -21,13 +21,15 @@ subprojects {
         dependencies {
             constraints {
                 add("implementation", "org.apache.logging.log4j:log4j-core:2.25.4") {
-                    because("Addresses CVE-2025-68161, CVE-2026-34477, and CVE-2026-34480")
+                    because(
+                        "Addresses CVE-2025-68161, CVE-2026-34477, CVE-2026-34478, and CVE-2026-34480",
+                    )
                 }
                 add("implementation", "commons-io:commons-io:2.22.0") {
                     because("Addresses CVE-2024-47554")
                 }
-                add("implementation", "org.codehaus.plexus:plexus-utils:3.6.1") {
-                    because("Addresses CVE-2025-67030")
+                add("implementation", "org.codehaus.plexus:plexus-utils:4.0.3") {
+                    because("Addresses CVE-2025-67030 (patched 4.x line)")
                 }
             }
         }

--- a/buildSrc/src/main/kotlin/graphus.java-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/graphus.java-conventions.gradle.kts
@@ -19,6 +19,7 @@ tasks.withType<Test>().configureEach {
 }
 
 dependencies {
+    implementation(platform("org.apache.logging.log4j:log4j-bom:2.25.4"))
     testImplementation(platform("org.junit:junit-bom:5.11.4"))
     testImplementation("org.junit.jupiter:junit-jupiter")
     testRuntimeOnly("org.junit.platform:junit-platform-launcher")


### PR DESCRIPTION
## Summary
Aligns dependency pins and BOM with patched versions for open Dependabot security alerts (#4, #5, #6, #7).

## Changes
- **log4j**: keep `log4j-core` constraint at 2.25.4; document CVE-2026-34478; add `log4j-bom` 2.25.4 to Java conventions.
- **plexus-utils**: raise constraint to **4.0.3** (CVE-2025-67030 patched 4.x line).

## Verification
- `./gradlew test`

Related to #37