### PR TITLE
fix(ci): use localhost for Chroma in publish benchmark

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -131,7 +131,7 @@ jobs:
 
       - name: Wait for Chroma
         env:
-          CHROMA_URL: http://chroma:8000
+          CHROMA_URL: http://127.0.0.1:8000
         run: |
           set -e
           for _ in $(seq 1 90); do
@@ -159,7 +159,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GRAPHUS_JAR: ${{ github.workspace }}/graphus.jar
-          CHROMA_URL: http://chroma:8000
+          CHROMA_URL: http://127.0.0.1:8000
           RELEASE_TAG: ${{ github.event.release.tag_name }}
           RUNNER_OS: ${{ runner.os }}-${{ runner.arch }}
           CHROMA_IMAGE: chromadb/chroma:1.1.0


### PR DESCRIPTION
## Summary

- Set `CHROMA_URL` to `http://127.0.0.1:8000` in the publish workflow benchmark job (wait loop and performance report step).
- Runner jobs without `container:` reach GitHub service containers via localhost and the published port, not the Docker service hostname `chroma`.

Related to #39