### PR TITLE
fix(deps): align plugin classpath for Dependabot graph

### DIFF
--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -6,3 +6,21 @@ repositories {
     mavenCentral()
     gradlePluginPortal()
 }
+
+configurations.configureEach {
+    resolutionStrategy.eachDependency {
+        when {
+            requested.group == "org.apache.logging.log4j" &&
+                requested.name in listOf("log4j-core", "log4j-api") -> {
+                useVersion("2.25.4")
+                because(
+                    "Align build/plugin classpath for GitHub dependency graph; CVE-2026-34477, CVE-2026-34478, CVE-2026-34480",
+                )
+            }
+            requested.group == "org.codehaus.plexus" && requested.name == "plexus-utils" -> {
+                useVersion("4.0.3")
+                because("CVE-2025-67030 (patched 4.x line)")
+            }
+        }
+    }
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,3 +1,30 @@
+pluginManagement {
+    repositories {
+        gradlePluginPortal()
+        mavenCentral()
+    }
+}
+
+gradle.beforeProject {
+    configurations.configureEach {
+        resolutionStrategy.eachDependency {
+            when {
+                requested.group == "org.apache.logging.log4j" &&
+                    requested.name in listOf("log4j-core", "log4j-api") -> {
+                    useVersion("2.25.4")
+                    because(
+                        "Align build/plugin classpath for GitHub dependency graph; CVE-2026-34477, CVE-2026-34478, CVE-2026-34480",
+                    )
+                }
+                requested.group == "org.codehaus.plexus" && requested.name == "plexus-utils" -> {
+                    useVersion("4.0.3")
+                    because("CVE-2025-67030 (patched 4.x line)")
+                }
+            }
+        }
+    }
+}
+
 rootProject.name = "graphus"
 
 include(


### PR DESCRIPTION
## Summary
- Register `resolutionStrategy.eachDependency` in `settings.gradle.kts` via `gradle.beforeProject` so every project configuration (including Shadow plugin resolution) bumps `log4j-core` / `log4j-api` to **2.25.4** and `plexus-utils` to **4.0.3**.
- Mirror the same rules in `buildSrc/build.gradle.kts` for the included build.

Dependabot’s submitted graph still showed vulnerable plugin-transitive versions from `com.gradleup.shadow` while runtime constraints were already correct.

## Verification
- `./gradlew build`

Related to #42