### PR TITLE
fix(deps): force patched Shadow transitives via buildscript

### DIFF
--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -6,21 +6,3 @@ repositories {
     mavenCentral()
     gradlePluginPortal()
 }
-
-configurations.configureEach {
-    resolutionStrategy.eachDependency {
-        when {
-            requested.group == "org.apache.logging.log4j" &&
-                requested.name in listOf("log4j-core", "log4j-api") -> {
-                useVersion("2.25.4")
-                because(
-                    "Align build/plugin classpath for GitHub dependency graph; CVE-2026-34477, CVE-2026-34478, CVE-2026-34480",
-                )
-            }
-            requested.group == "org.codehaus.plexus" && requested.name == "plexus-utils" -> {
-                useVersion("4.0.3")
-                because("CVE-2025-67030 (patched 4.x line)")
-            }
-        }
-    }
-}

--- a/graphus-cli/build.gradle.kts
+++ b/graphus-cli/build.gradle.kts
@@ -1,10 +1,38 @@
 import org.gradle.api.publish.maven.tasks.AbstractPublishToMaven
 
+buildscript {
+    repositories {
+        gradlePluginPortal()
+        mavenCentral()
+    }
+    configurations.classpath {
+        resolutionStrategy.eachDependency {
+            when {
+                requested.group == "org.apache.logging.log4j" &&
+                    requested.name in listOf("log4j-core", "log4j-api") -> {
+                    useVersion("2.25.4")
+                    because(
+                        "Align Shadow plugin classpath for GitHub dependency graph; CVE-2026-34477, CVE-2026-34478, CVE-2026-34480",
+                    )
+                }
+                requested.group == "org.codehaus.plexus" && requested.name == "plexus-utils" -> {
+                    useVersion("4.0.3")
+                    because("CVE-2025-67030 (patched 4.x line)")
+                }
+            }
+        }
+    }
+    dependencies {
+        classpath("com.gradleup.shadow:shadow-gradle-plugin:9.4.0")
+    }
+}
+
 plugins {
     id("graphus.java-conventions")
     application
-    id("com.gradleup.shadow") version "9.4.0"
 }
+
+apply(plugin = "com.gradleup.shadow")
 
 dependencies {
     implementation(project(":graphus-model"))

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -5,26 +5,6 @@ pluginManagement {
     }
 }
 
-gradle.beforeProject {
-    configurations.configureEach {
-        resolutionStrategy.eachDependency {
-            when {
-                requested.group == "org.apache.logging.log4j" &&
-                    requested.name in listOf("log4j-core", "log4j-api") -> {
-                    useVersion("2.25.4")
-                    because(
-                        "Align build/plugin classpath for GitHub dependency graph; CVE-2026-34477, CVE-2026-34478, CVE-2026-34480",
-                    )
-                }
-                requested.group == "org.codehaus.plexus" && requested.name == "plexus-utils" -> {
-                    useVersion("4.0.3")
-                    because("CVE-2025-67030 (patched 4.x line)")
-                }
-            }
-        }
-    }
-}
-
 rootProject.name = "graphus"
 
 include(


### PR DESCRIPTION
## Summary
Follow-up to #43: `gradle.beforeProject { configurations… }` did not affect the **Shadow** plugin classpath (`:graphus-cli:buildEnvironment` still resolved log4j 2.25.3 / plexus-utils 4.0.2), so GitHub’s dependency SBOM and Dependabot alerts did not clear.

- **`graphus-cli`**: load `shadow-gradle-plugin` via **`buildscript.dependencies`** with `classpath` **resolutionStrategy.eachDependency** to bump **log4j-core** / **log4j-api** → **2.25.4** and **plexus-utils** → **4.0.3**, then **`apply(plugin = \"com.gradleup.shadow\")`** (still **9.4.0**).
- **`settings.gradle.kts` / `buildSrc`**: remove the ineffective global hooks.

## Verification
- `./gradlew build`
- `./gradlew :graphus-cli:buildEnvironment` shows `2.25.3 -> 2.25.4` and `4.0.2 -> 4.0.3` on the plugin classpath.

Related to #42