### PR TITLE
fix(model): sync MethodNode callers/callees on edge and node removal

### DIFF
--- a/graphus-model/src/main/java/io/graphus/model/CallGraph.java
+++ b/graphus-model/src/main/java/io/graphus/model/CallGraph.java
@@ -57,6 +57,14 @@ public final class CallGraph {
      */
     public void removeEdge(String fromId, String toId) {
         edges.removeIf(edge -> edge.fromId().equals(fromId) && edge.toId().equals(toId));
+        SymbolNode from = nodes.get(fromId);
+        SymbolNode to = nodes.get(toId);
+        if (from instanceof MethodNode fromMethod) {
+            fromMethod.removeCallee(toId);
+        }
+        if (to instanceof MethodNode toMethod) {
+            toMethod.removeCaller(fromId);
+        }
     }
 
     /**
@@ -68,6 +76,19 @@ public final class CallGraph {
             return;
         }
         nodes.remove(id);
+        for (CallEdge edge : edges) {
+            if (edge.fromId().equals(id)) {
+                SymbolNode to = nodes.get(edge.toId());
+                if (to instanceof MethodNode toMethod) {
+                    toMethod.removeCaller(id);
+                }
+            } else if (edge.toId().equals(id)) {
+                SymbolNode from = nodes.get(edge.fromId());
+                if (from instanceof MethodNode fromMethod) {
+                    fromMethod.removeCallee(id);
+                }
+            }
+        }
         edges.removeIf(edge -> edge.fromId().equals(id) || edge.toId().equals(id));
     }
 

--- a/graphus-model/src/main/java/io/graphus/model/MethodNode.java
+++ b/graphus-model/src/main/java/io/graphus/model/MethodNode.java
@@ -123,6 +123,14 @@ public final class MethodNode extends SymbolNode {
         }
     }
 
+    public void removeCallee(String calleeId) {
+        callees.remove(calleeId);
+    }
+
+    public void removeCaller(String callerId) {
+        callers.remove(callerId);
+    }
+
     public SpringMetadata getSpringMetadata() {
         return springMetadata;
     }

--- a/graphus-parser/src/test/java/io/graphus/parser/CrossLanguageCallResolverTest.java
+++ b/graphus-parser/src/test/java/io/graphus/parser/CrossLanguageCallResolverTest.java
@@ -62,6 +62,39 @@ class CrossLanguageCallResolverTest {
     }
 
     @Test
+    void callerCalleesDoNotRetainStaleUnresolvedIdAfterResolution() {
+        CallGraph graph = new CallGraph();
+        MethodNode caller = method("com.demo.JavaClient.use()", "use", "use()");
+        graph.addNode(caller);
+
+        MethodNode target = method("com.demo.KotlinService.greet(String)", "greet", "greet(String)");
+        graph.addNode(target);
+
+        UnresolvedNode unresolved =
+                new UnresolvedNode("UNRESOLVED:greet(name)", "greet(name)", "Java.java", 7);
+        graph.addNode(unresolved);
+        graph.addEdge(caller.getId(), unresolved.getId());
+
+        UnresolvedCallRecord record =
+                new UnresolvedCallRecord(caller.getId(), "greet", 1, unresolved.getId(),
+                        UnresolvedCallRecord.Origin.JAVA);
+
+        new CrossLanguageCallResolver().resolve(
+                graph,
+                Set.of(caller.getId()),
+                Set.of(target.getId()),
+                List.of(record),
+                List.of());
+
+        assertFalse(caller.getCallees().contains(unresolved.getId()),
+                "Stale unresolved callee must not remain after resolution");
+        assertTrue(caller.getCallees().contains(target.getId()),
+                "Caller must reference resolved callee id");
+        assertTrue(target.getCallers().contains(caller.getId()),
+                "Resolved target must list caller");
+    }
+
+    @Test
     void replacesKotlinUnresolvedWithDirectJavaEdgeOnUniqueMatch() {
         CallGraph graph = new CallGraph();
         MethodNode kotlinCaller = method("com.demo.KotlinClient.run()", "run", "run()");


### PR DESCRIPTION
## Summary

- Keep `MethodNode.callers` / `MethodNode.callees` aligned with the `edges` set when `removeEdge` or `removeNode` runs so cross-language resolution does not leave stale `UNRESOLVED:…` ids.
- Add `removeCallee` / `removeCaller` on `MethodNode` and invoke them from `CallGraph.removeEdge` / `removeNode`.
- Add `callerCalleesDoNotRetainStaleUnresolvedIdAfterResolution` regression test in `CrossLanguageCallResolverTest`.

## Test plan

- [x] `./gradlew :graphus-parser:test --tests "io.graphus.parser.CrossLanguageCallResolverTest"`

Related to #52