### PR TITLE
Add Cursor Cloud specific instructions to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -65,3 +65,12 @@ Any change to how Graphus is built, packaged, or distributed — including chang
 - Vector backend + embedding settings must stay consistent across `index`/`sync`/`query` unless intentionally reconfigured
 
 See [Conventions](docs/conventions.md) for full details.
+
+## Cursor Cloud specific instructions
+
+- **Java 21** is pre-installed on the VM (`/usr/bin/java`). No version manager setup needed.
+- **Build & test**: `./gradlew build` compiles all four modules and runs JUnit 5 tests. The shadow JAR lands at `graphus-cli/build/libs/graphus.jar`.
+- **No dedicated lint task** — the project has no checkstyle/spotless/PMD plugins; compilation + tests are the quality gate.
+- **Running the CLI locally**: `java -jar graphus-cli/build/libs/graphus.jar <command> [options]`. Use `--db sqlite --embedding local` for a fully offline run (no Docker/ChromaDB/OpenAI needed).
+- **ChromaDB is optional** — only required for `--db chroma`. If needed, `docker compose up -d` starts it on port 8000, but Docker must be installed first (not pre-installed on the VM).
+- **`.graphus/` directory** is generated state (checksums, config, SQLite DB) — always clean it up after demo runs and never commit it.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds a `## Cursor Cloud specific instructions` section to `AGENTS.md` with practical notes for future cloud agents:

- Java 21 pre-installed; no version manager needed
- Build/test via `./gradlew build`; no separate lint task
- CLI invocation with `--db sqlite --embedding local` for fully offline runs
- ChromaDB is optional (Docker not pre-installed on VM)
- `.graphus/` is generated state — never commit it

**Validation**

Full build + tests passed, shadow JAR built, and CLI exercised end-to-end (index, query, blast-radius) on the Graphus codebase itself.

[build_and_demo.log](https://cursor.com/agents/bc-8d1fff2e-8de4-4a55-9eb6-0e66d8d8d6aa/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fbuild_and_demo.log)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8d1fff2e-8de4-4a55-9eb6-0e66d8d8d6aa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8d1fff2e-8de4-4a55-9eb6-0e66d8d8d6aa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

