### PR TITLE
feat(parser): add module dependency graph from Gradle build files

### DIFF
--- a/graphus-indexer/src/main/java/io/graphus/indexer/SymbolChunkBuilder.java
+++ b/graphus-indexer/src/main/java/io/graphus/indexer/SymbolChunkBuilder.java
@@ -6,6 +6,7 @@ import io.graphus.model.ClassNode;
 import io.graphus.model.FieldNode;
 import io.graphus.model.MethodNode;
 import io.graphus.model.ModuleDescriptor;
+import io.graphus.model.ModuleNode;
 import io.graphus.model.SymbolKind;
 import io.graphus.model.SymbolNode;
 import io.graphus.model.UnresolvedNode;
@@ -61,7 +62,7 @@ public final class SymbolChunkBuilder {
 
         for (SymbolNode node : nodes) {
             Metadata metadata = metadataFor(node, workspace);
-            String text = chunkText(node, callGraph);
+            String text = chunkText(node, callGraph, workspace);
             chunks.add(new SymbolChunk(node.getId(), text, metadata));
         }
 
@@ -81,7 +82,7 @@ public final class SymbolChunkBuilder {
         Metadata metadata = new Metadata()
                 .put("fqn", node.getId())
                 .put("kind", node.getKind().name())
-                .put("file", node.getFilePath())
+                .put("file", node.getFilePath() != null ? node.getFilePath() : "")
                 .put("line", node.getLine());
 
         if (node instanceof ClassNode classNode) {
@@ -109,13 +110,28 @@ public final class SymbolChunkBuilder {
         return metadata;
     }
 
-    private String chunkText(SymbolNode node, CallGraph callGraph) {
+    private String chunkText(SymbolNode node, CallGraph callGraph, Optional<WorkspaceDescriptor> workspace) {
+        if (node instanceof ModuleNode moduleNode) {
+            Set<String> depIds = callGraph.outgoingNeighbors(moduleNode.getId());
+            String deps = depIds.stream()
+                    .filter(id -> id.startsWith(ModuleNode.ID_PREFIX))
+                    .map(id -> id.substring(ModuleNode.ID_PREFIX.length()))
+                    .collect(Collectors.joining(", "));
+            return "[MODULE] " + moduleNode.getModuleName() + "\n"
+                    + "Depends On: " + deps + "\n";
+        }
+        String moduleTag = workspace
+                .map(ws -> resolveModuleMetadataTag(node.getFilePath(), ws))
+                .orElse(null);
+        String moduleLine = moduleTag != null ? "Module: " + moduleTag + "\n" : "";
+
         if (node instanceof MethodNode methodNode) {
             String mappings = methodNode.getSpringMetadata().getHttpMappings().stream()
                     .map(mapping -> mapping.method() + " " + mapping.path())
                     .collect(Collectors.joining(", "));
             String kindLabel = methodNode.getKind() == SymbolKind.CONSTRUCTOR ? "CONSTRUCTOR" : "METHOD";
             return "[" + kindLabel + "] " + methodNode.getId() + "\n"
+                    + moduleLine
                     + "Class: " + methodNode.getDeclaringClassId() + "\n"
                     + "Signature: " + methodNode.getSignature() + "\n"
                     + "Return: " + methodNode.getReturnType() + "\n"
@@ -134,6 +150,7 @@ public final class SymbolChunkBuilder {
         }
         if (node instanceof ClassNode classNode) {
             return "[CLASS] " + classNode.getId() + "\n"
+                    + moduleLine
                     + "Simple Name: " + classNode.getSimpleName() + "\n"
                     + "Annotations: " + String.join(", ", classNode.getAnnotations()) + "\n"
                     + "Superclass: " + classNode.getSuperClass() + "\n"
@@ -147,6 +164,7 @@ public final class SymbolChunkBuilder {
         }
         if (node instanceof FieldNode fieldNode) {
             return "[FIELD] " + fieldNode.getId() + "\n"
+                    + moduleLine
                     + "Class: " + fieldNode.getDeclaringClassId() + "\n"
                     + "Name: " + fieldNode.getName() + "\n"
                     + "Type: " + fieldNode.getType() + "\n"

--- a/graphus-model/src/main/java/io/graphus/model/ModuleNode.java
+++ b/graphus-model/src/main/java/io/graphus/model/ModuleNode.java
@@ -1,0 +1,31 @@
+package io.graphus.model;
+
+/**
+ * Represents a Gradle or Maven module as a node in the call graph. Used to model
+ * inter-module {@code MODULE_DEPENDS_ON} edges discovered from build files.
+ *
+ * <p>The node ID follows the convention {@code module:<module-name>} where
+ * {@code module-name} matches {@link ModuleDescriptor#name()}.
+ */
+public final class ModuleNode extends SymbolNode {
+
+    public static final String ID_PREFIX = "module:";
+
+    private final String moduleName;
+
+    public ModuleNode(String moduleName) {
+        super(ID_PREFIX + moduleName, SymbolKind.MODULE, "", 0);
+        if (moduleName == null || moduleName.isBlank()) {
+            throw new IllegalArgumentException("moduleName must not be blank");
+        }
+        this.moduleName = moduleName;
+    }
+
+    public String getModuleName() {
+        return moduleName;
+    }
+
+    public static String idFor(String moduleName) {
+        return ID_PREFIX + moduleName;
+    }
+}

--- a/graphus-model/src/main/java/io/graphus/model/SymbolKind.java
+++ b/graphus-model/src/main/java/io/graphus/model/SymbolKind.java
@@ -6,5 +6,6 @@ public enum SymbolKind {
     CONSTRUCTOR,
     FIELD,
     ANNOTATION,
-    UNRESOLVED
+    UNRESOLVED,
+    MODULE
 }

--- a/graphus-parser/src/main/java/io/graphus/parser/GradleModuleDependencyParser.java
+++ b/graphus-parser/src/main/java/io/graphus/parser/GradleModuleDependencyParser.java
@@ -1,0 +1,107 @@
+package io.graphus.parser;
+
+import io.graphus.model.CallGraph;
+import io.graphus.model.ModuleDescriptor;
+import io.graphus.model.ModuleNode;
+import io.graphus.model.WorkspaceDescriptor;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Parses Gradle build files to extract inter-module dependencies and adds synthetic
+ * {@code MODULE_DEPENDS_ON} edges to the call graph.
+ *
+ * <p>Recognises both Kotlin DSL ({@code implementation(project(":module"))}) and
+ * Groovy DSL ({@code implementation project(':module')}) syntax. Only production
+ * dependency configurations are included — {@code testImplementation}, {@code testApi},
+ * etc. are ignored.
+ */
+public final class GradleModuleDependencyParser {
+
+    // Matches KTS: implementation(project(":module")) and Groovy: implementation project(':module')
+    private static final Pattern PROJECT_DEP = Pattern.compile(
+            "\\b(?:implementation|api|compileOnly|runtimeOnly)\\s*\\(?\\s*project\\s*\\(\\s*[\"']([^\"']+)[\"']"
+    );
+
+    private GradleModuleDependencyParser() {
+    }
+
+    /**
+     * Adds a {@link ModuleNode} for every module in {@code workspace} to the graph, then
+     * parses each module's {@code build.gradle.kts} (falling back to {@code build.gradle})
+     * to add {@code module:A → module:B} edges for {@code implementation/api project(...)}
+     * declarations.
+     *
+     * @return number of inter-module dependency edges added
+     */
+    public static int resolve(CallGraph callGraph, WorkspaceDescriptor workspace) throws IOException {
+        for (ModuleDescriptor module : workspace.modules()) {
+            callGraph.addNode(new ModuleNode(module.name()));
+        }
+
+        int edgesAdded = 0;
+        for (ModuleDescriptor module : workspace.modules()) {
+            List<String> depModuleNames = parseDependencies(module.root(), workspace);
+            for (String depName : depModuleNames) {
+                callGraph.addEdge(ModuleNode.idFor(module.name()), ModuleNode.idFor(depName));
+                edgesAdded++;
+            }
+        }
+        return edgesAdded;
+    }
+
+    /**
+     * Parses production project-to-project dependencies from the build file at {@code moduleRoot}.
+     */
+    static List<String> parseDependencies(Path moduleRoot, WorkspaceDescriptor workspace) throws IOException {
+        Path buildFile = moduleRoot.resolve("build.gradle.kts");
+        if (!Files.isRegularFile(buildFile)) {
+            buildFile = moduleRoot.resolve("build.gradle");
+        }
+        if (!Files.isRegularFile(buildFile)) {
+            return List.of();
+        }
+
+        String content = Files.readString(buildFile, StandardCharsets.UTF_8);
+        content = stripLineComments(content);
+
+        List<String> deps = new ArrayList<>();
+        Matcher matcher = PROJECT_DEP.matcher(content);
+        while (matcher.find()) {
+            String gradlePath = matcher.group(1);
+            String relativePath = GradleSettingsParser.gradleIncludeToRelativePath(gradlePath);
+            if (relativePath.isBlank()) {
+                continue;
+            }
+            String moduleName = relativePath.replace("/", "__");
+            if (moduleExists(moduleName, workspace)) {
+                deps.add(moduleName);
+            }
+        }
+        return List.copyOf(deps);
+    }
+
+    private static boolean moduleExists(String moduleName, WorkspaceDescriptor workspace) {
+        for (ModuleDescriptor module : workspace.modules()) {
+            if (module.name().equals(moduleName)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static String stripLineComments(String text) {
+        StringBuilder sb = new StringBuilder();
+        for (String line : text.lines().toList()) {
+            int idx = GradleSettingsParser.lineCommentStart(line);
+            sb.append(idx >= 0 ? line.substring(0, idx) : line).append('\n');
+        }
+        return sb.toString();
+    }
+}

--- a/graphus-parser/src/main/java/io/graphus/parser/ProjectParser.java
+++ b/graphus-parser/src/main/java/io/graphus/parser/ProjectParser.java
@@ -59,7 +59,14 @@ public final class ProjectParser {
                 }
             }
         }
-        return parseInternal(repositoryRoot, javaRoots, kotlinRoots, progressListener);
+        ProjectParserResult result = parseInternal(repositoryRoot, javaRoots, kotlinRoots, progressListener);
+
+        // ---- Module dependency graph ----
+        if (workspace.isMultiModule()) {
+            GradleModuleDependencyParser.resolve(result.callGraph(), workspace);
+        }
+
+        return result;
     }
 
     private ProjectParserResult parseInternal(

--- a/graphus-parser/src/test/java/io/graphus/parser/GradleModuleDependencyParserTest.java
+++ b/graphus-parser/src/test/java/io/graphus/parser/GradleModuleDependencyParserTest.java
@@ -1,0 +1,175 @@
+package io.graphus.parser;
+
+import io.graphus.model.CallEdge;
+import io.graphus.model.CallGraph;
+import io.graphus.model.ModuleDescriptor;
+import io.graphus.model.ModuleNode;
+import io.graphus.model.WorkspaceDescriptor;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class GradleModuleDependencyParserTest {
+
+    @Test
+    void addsModuleNodesAndEdgeForSingleDependency(@TempDir Path repoRoot) throws IOException {
+        setupModule(repoRoot, "module-a", """
+                dependencies {
+                    implementation(project(":module-b"))
+                }
+                """);
+        setupModule(repoRoot, "module-b", "");
+
+        WorkspaceDescriptor workspace = workspace(repoRoot, "module-a", "module-b");
+        CallGraph graph = new CallGraph();
+
+        int edgesAdded = GradleModuleDependencyParser.resolve(graph, workspace);
+
+        assertEquals(1, edgesAdded);
+        assertTrue(graph.getNodes().stream().anyMatch(n -> n.getId().equals("module:module-a")));
+        assertTrue(graph.getNodes().stream().anyMatch(n -> n.getId().equals("module:module-b")));
+        assertTrue(graph.getEdges().contains(new CallEdge("module:module-a", "module:module-b")));
+    }
+
+    @Test
+    void addsMultipleEdgesWhenModuleHasMultipleDependencies(@TempDir Path repoRoot) throws IOException {
+        setupModule(repoRoot, "module-a", """
+                dependencies {
+                    implementation(project(":module-b"))
+                    api(project(":module-c"))
+                }
+                """);
+        setupModule(repoRoot, "module-b", "");
+        setupModule(repoRoot, "module-c", "");
+
+        WorkspaceDescriptor workspace = workspace(repoRoot, "module-a", "module-b", "module-c");
+        CallGraph graph = new CallGraph();
+
+        int edgesAdded = GradleModuleDependencyParser.resolve(graph, workspace);
+
+        assertEquals(2, edgesAdded);
+        assertTrue(graph.getEdges().contains(new CallEdge("module:module-a", "module:module-b")));
+        assertTrue(graph.getEdges().contains(new CallEdge("module:module-a", "module:module-c")));
+    }
+
+    @Test
+    void returnsZeroWhenNoBuildFile(@TempDir Path repoRoot) throws IOException {
+        setupModule(repoRoot, "module-a", null);  // no build file
+        setupModule(repoRoot, "module-b", "");
+
+        WorkspaceDescriptor workspace = workspace(repoRoot, "module-a", "module-b");
+        CallGraph graph = new CallGraph();
+
+        int edgesAdded = GradleModuleDependencyParser.resolve(graph, workspace);
+
+        assertEquals(0, edgesAdded);
+        assertEquals(2, graph.getNodes().size());  // ModuleNodes still added
+        assertTrue(graph.getEdges().isEmpty());
+    }
+
+    @Test
+    void excludesTestDependencies(@TempDir Path repoRoot) throws IOException {
+        setupModule(repoRoot, "module-a", """
+                dependencies {
+                    testImplementation(project(":module-b"))
+                    testApi(project(":module-b"))
+                }
+                """);
+        setupModule(repoRoot, "module-b", "");
+
+        WorkspaceDescriptor workspace = workspace(repoRoot, "module-a", "module-b");
+        CallGraph graph = new CallGraph();
+
+        int edgesAdded = GradleModuleDependencyParser.resolve(graph, workspace);
+
+        assertEquals(0, edgesAdded);
+        assertTrue(graph.getEdges().isEmpty());
+    }
+
+    @Test
+    void parsesGroovyDslSyntax(@TempDir Path repoRoot) throws IOException {
+        setupModuleGroovy(repoRoot, "module-a", """
+                dependencies {
+                    implementation project(':module-b')
+                    api project(':module-c')
+                }
+                """);
+        setupModule(repoRoot, "module-b", "");
+        setupModule(repoRoot, "module-c", "");
+
+        WorkspaceDescriptor workspace = workspace(repoRoot, "module-a", "module-b", "module-c");
+        CallGraph graph = new CallGraph();
+
+        int edgesAdded = GradleModuleDependencyParser.resolve(graph, workspace);
+
+        assertEquals(2, edgesAdded);
+        assertTrue(graph.getEdges().contains(new CallEdge("module:module-a", "module:module-b")));
+        assertTrue(graph.getEdges().contains(new CallEdge("module:module-a", "module:module-c")));
+    }
+
+    @Test
+    void skipsExternalDependenciesAndNonExistentModules(@TempDir Path repoRoot) throws IOException {
+        setupModule(repoRoot, "module-a", """
+                dependencies {
+                    implementation("com.example:library:1.0")
+                    implementation(project(":unknown-module"))
+                }
+                """);
+
+        WorkspaceDescriptor workspace = workspace(repoRoot, "module-a");
+        CallGraph graph = new CallGraph();
+
+        int edgesAdded = GradleModuleDependencyParser.resolve(graph, workspace);
+
+        assertEquals(0, edgesAdded);
+        assertTrue(graph.getEdges().isEmpty());
+    }
+
+    @Test
+    void moduleNodeIdFollowsConvention(@TempDir Path repoRoot) throws IOException {
+        setupModule(repoRoot, "my-service", "");
+
+        WorkspaceDescriptor workspace = workspace(repoRoot, "my-service");
+        CallGraph graph = new CallGraph();
+        GradleModuleDependencyParser.resolve(graph, workspace);
+
+        assertTrue(graph.getNodes().stream()
+                .anyMatch(n -> n instanceof ModuleNode && n.getId().equals("module:my-service")));
+    }
+
+    // ---- helpers ----
+
+    private static void setupModule(Path repoRoot, String moduleName, String buildContent) throws IOException {
+        Path moduleDir = repoRoot.resolve(moduleName);
+        Path srcMain = moduleDir.resolve("src/main/java");
+        Files.createDirectories(srcMain);
+        if (buildContent != null) {
+            Files.writeString(moduleDir.resolve("build.gradle.kts"), buildContent);
+        }
+    }
+
+    private static void setupModuleGroovy(Path repoRoot, String moduleName, String buildContent) throws IOException {
+        Path moduleDir = repoRoot.resolve(moduleName);
+        Path srcMain = moduleDir.resolve("src/main/java");
+        Files.createDirectories(srcMain);
+        if (buildContent != null) {
+            Files.writeString(moduleDir.resolve("build.gradle"), buildContent);
+        }
+    }
+
+    private static WorkspaceDescriptor workspace(Path repoRoot, String... moduleNames) {
+        List<ModuleDescriptor> modules = new java.util.ArrayList<>();
+        for (String name : moduleNames) {
+            Path moduleRoot = repoRoot.resolve(name).toAbsolutePath().normalize();
+            Path javaRoot = moduleRoot.resolve("src/main/java");
+            modules.add(new ModuleDescriptor(name, moduleRoot, List.of(javaRoot)));
+        }
+        return new WorkspaceDescriptor(repoRoot.getFileName().toString(), repoRoot, modules);
+    }
+}


### PR DESCRIPTION
## Summary

- Adds `ModuleNode` (new `SymbolKind.MODULE`) and `GradleModuleDependencyParser` to emit `MODULE_DEPENDS_ON` edges between modules discovered from `build.gradle.kts` / `build.gradle` files
- Parses `implementation(project(":module"))` and `api(project(":module"))` in both Kotlin DSL and Groovy DSL; ignores `testImplementation` / `testApi` to keep production-only edges
- Integrates into `ProjectParser.parse(WorkspaceDescriptor, …)` as a post-pass after Guice resolution
- Updates `SymbolChunkBuilder` to include `Module: <name>` in class/method/field chunk text (previously metadata-only) and to emit `[MODULE]` chunks for the dependency graph itself — enables `query "modules that depend on X"`

## Test plan

- [ ] `GradleModuleDependencyParserTest` — 7 tests: single dep, multiple deps, no build file, excludes test deps, Groovy DSL, skips external/unknown modules, node ID convention
- [ ] Full build passes: `./gradlew build`

Related to #68