### PR TITLE
feat(cli): add git intelligence commands — git-analyze, hotspots, snapshot, drift

### DIFF
--- a/graphus-cli/src/main/java/io/graphus/cli/DriftCommand.java
+++ b/graphus-cli/src/main/java/io/graphus/cli/DriftCommand.java
@@ -1,0 +1,181 @@
+package io.graphus.cli;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeSet;
+import java.util.concurrent.Callable;
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Parameters;
+
+/**
+ * Diffs two snapshots produced by {@code graphus snapshot} and reports architectural changes —
+ * what grew, shrunk, appeared, or disappeared.
+ */
+@Command(name = "drift",
+        description = "Compare two graph snapshots and report architectural drift")
+public final class DriftCommand implements Callable<Integer> {
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+    private static final TypeReference<Map<String, Object>> MAP_TYPE = new TypeReference<>() {};
+
+    @Parameters(paramLabel = "SNAPSHOT_A", index = "0",
+            description = "Path to the baseline snapshot JSON (older)")
+    private Path snapshotA;
+
+    @Parameters(paramLabel = "SNAPSHOT_B", index = "1",
+            description = "Path to the comparison snapshot JSON (newer)")
+    private Path snapshotB;
+
+    @Override
+    public Integer call() throws Exception {
+        Map<String, Object> a = MAPPER.readValue(snapshotA.toFile(), MAP_TYPE);
+        Map<String, Object> b = MAPPER.readValue(snapshotB.toFile(), MAP_TYPE);
+
+        System.out.println(phase("Snapshot A: ") + label(a) + "  (" + snapshotA.getFileName() + ")");
+        System.out.println(phase("Snapshot B: ") + label(b) + "  (" + snapshotB.getFileName() + ")");
+        System.out.println(Ansi.style("---", Ansi.DIM));
+
+        // ---- top-level counters ----
+        reportDelta("Parsed files    ", a, b, "parsedFiles");
+        reportDelta("Total nodes     ", a, b, "totalNodes");
+        reportDelta("Total edges     ", a, b, "totalEdges");
+        reportDelta("Total files     ", a, b, "totalFiles");
+        reportDelta("Unresolved calls", a, b, "unresolvedCalls");
+        reportDelta("Module count    ", a, b, "moduleCount");
+        System.out.println(Ansi.style("---", Ansi.DIM));
+
+        // ---- nodes by kind ----
+        System.out.println(phase("Nodes by kind:"));
+        @SuppressWarnings("unchecked")
+        Map<String, Object> kindA = (Map<String, Object>) a.getOrDefault("nodesByKind", Map.of());
+        @SuppressWarnings("unchecked")
+        Map<String, Object> kindB = (Map<String, Object>) b.getOrDefault("nodesByKind", Map.of());
+        Set<String> allKinds = new TreeSet<>();
+        allKinds.addAll(kindA.keySet());
+        allKinds.addAll(kindB.keySet());
+        for (String kind : allKinds) {
+            int va = toInt(kindA.get(kind));
+            int vb = toInt(kindB.get(kind));
+            System.out.println("  " + String.format("%-16s", kind) + formatDelta(va, vb));
+        }
+        System.out.println(Ansi.style("---", Ansi.DIM));
+
+        // ---- module changes ----
+        @SuppressWarnings("unchecked")
+        List<String> modulesA = (List<String>) a.getOrDefault("modules", List.of());
+        @SuppressWarnings("unchecked")
+        List<String> modulesB = (List<String>) b.getOrDefault("modules", List.of());
+        Set<String> added = new TreeSet<>(modulesB);
+        added.removeAll(modulesA);
+        Set<String> removed = new TreeSet<>(modulesA);
+        removed.removeAll(modulesB);
+        if (!added.isEmpty() || !removed.isEmpty()) {
+            System.out.println(phase("Module changes:"));
+            for (String m : added) {
+                System.out.println(Ansi.style("  + " + m, Ansi.GREEN));
+            }
+            for (String m : removed) {
+                System.out.println(Ansi.style("  - " + m, Ansi.RED));
+            }
+            System.out.println(Ansi.style("---", Ansi.DIM));
+        }
+
+        // ---- top coupled node changes ----
+        @SuppressWarnings("unchecked")
+        List<Map<String, Object>> topA = (List<Map<String, Object>>) a.getOrDefault("topCoupledNodes", List.of());
+        @SuppressWarnings("unchecked")
+        List<Map<String, Object>> topB = (List<Map<String, Object>>) b.getOrDefault("topCoupledNodes", List.of());
+        reportTopCoupledChanges(topA, topB);
+
+        return 0;
+    }
+
+    private static void reportDelta(String label, Map<String, Object> a, Map<String, Object> b,
+            String key) {
+        int va = toInt(a.get(key));
+        int vb = toInt(b.get(key));
+        System.out.println(String.format("%-18s", label) + formatDelta(va, vb));
+    }
+
+    private static String formatDelta(int before, int after) {
+        int delta = after - before;
+        String base = before + " → " + after;
+        if (delta == 0) {
+            return Ansi.style(base + "  (no change)", Ansi.DIM);
+        }
+        String sign = delta > 0 ? "+" : "";
+        String deltaStr = "  (" + sign + delta + ")";
+        return delta > 0
+                ? base + Ansi.style(deltaStr, Ansi.GREEN)
+                : base + Ansi.style(deltaStr, Ansi.RED);
+    }
+
+    private static void reportTopCoupledChanges(
+            List<Map<String, Object>> topA, List<Map<String, Object>> topB) {
+        Map<String, Integer> mapA = toIdEdgeMap(topA);
+        Map<String, Integer> mapB = toIdEdgeMap(topB);
+
+        List<String> newEntrants = new ArrayList<>();
+        List<String> disappeared = new ArrayList<>();
+        List<String> changed = new ArrayList<>();
+
+        for (String id : mapB.keySet()) {
+            if (!mapA.containsKey(id)) {
+                newEntrants.add(id + " (" + mapB.get(id) + " incoming edges)");
+            } else {
+                int delta = mapB.get(id) - mapA.get(id);
+                if (delta != 0) {
+                    String sign = delta > 0 ? "+" : "";
+                    changed.add(id + " " + sign + delta + " edges (" + mapA.get(id) + " → " + mapB.get(id) + ")");
+                }
+            }
+        }
+        for (String id : mapA.keySet()) {
+            if (!mapB.containsKey(id)) {
+                disappeared.add(id);
+            }
+        }
+
+        if (!newEntrants.isEmpty() || !disappeared.isEmpty() || !changed.isEmpty()) {
+            System.out.println(phase("Top coupled node changes:"));
+            newEntrants.forEach(s -> System.out.println(Ansi.style("  + " + s, Ansi.GREEN)));
+            disappeared.forEach(s -> System.out.println(Ansi.style("  - " + s, Ansi.RED)));
+            changed.forEach(s -> System.out.println("  ~ " + s));
+        }
+    }
+
+    private static Map<String, Integer> toIdEdgeMap(List<Map<String, Object>> list) {
+        Map<String, Integer> map = new LinkedHashMap<>();
+        for (Map<String, Object> entry : list) {
+            String id = (String) entry.get("id");
+            int edges = toInt(entry.get("incomingEdges"));
+            if (id != null) {
+                map.put(id, edges);
+            }
+        }
+        return map;
+    }
+
+    private static int toInt(Object value) {
+        if (value == null) return 0;
+        if (value instanceof Number n) return n.intValue();
+        try { return Integer.parseInt(value.toString()); } catch (NumberFormatException e) { return 0; }
+    }
+
+    private static String label(Map<String, Object> snapshot) {
+        Object lbl = snapshot.get("label");
+        Object at = snapshot.get("createdAt");
+        String atStr = at != null ? at.toString() : "unknown";
+        return lbl != null ? Ansi.style(lbl.toString(), Ansi.CYAN) + " @ " + atStr : atStr;
+    }
+
+    private static String phase(String value) {
+        return Ansi.style(value, Ansi.BOLD);
+    }
+}

--- a/graphus-cli/src/main/java/io/graphus/cli/GitAnalyzeCommand.java
+++ b/graphus-cli/src/main/java/io/graphus/cli/GitAnalyzeCommand.java
@@ -1,0 +1,142 @@
+package io.graphus.cli;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import io.graphus.cli.git.ChurnAnalyzer;
+import io.graphus.cli.git.CoChangeAnalyzer;
+import io.graphus.cli.git.GitLogParser;
+import io.graphus.cli.git.OwnershipAnalyzer;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.Callable;
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Option;
+
+/**
+ * Mines git history to compute per-file co-change frequencies and primary ownership.
+ * Outputs {@code .graphus/co-changes.json} and {@code .graphus/ownership.json}.
+ */
+@Command(name = "git-analyze",
+        description = "Mine git history for co-change frequencies and file ownership")
+public final class GitAnalyzeCommand implements Callable<Integer> {
+
+    private static final ObjectMapper MAPPER =
+            new ObjectMapper().enable(SerializationFeature.INDENT_OUTPUT);
+
+    @Option(names = "--repo", defaultValue = ".", description = "Repository root path")
+    private Path repositoryRoot;
+
+    @Option(names = "--state-dir",
+            description = "Directory to write co-changes.json and ownership.json (default: .graphus)")
+    private Path stateDir;
+
+    @Option(names = "--since", defaultValue = "365",
+            description = "Analyse commits from the last N days (0 = all history)")
+    private int sinceDays;
+
+    @Option(names = "--threshold", defaultValue = "3",
+            description = "Minimum co-change count for a file pair to be included")
+    private int threshold;
+
+    @Override
+    public Integer call() throws Exception {
+        long start = System.nanoTime();
+        Path repoRoot = repositoryRoot.toAbsolutePath().normalize();
+        Path resolvedStateDir = stateDir != null
+                ? stateDir.toAbsolutePath().normalize()
+                : repoRoot.resolve(".graphus").normalize();
+        Files.createDirectories(resolvedStateDir);
+
+        System.out.println(phase("Analysing git history (last " + sinceDays + " days)..."));
+        List<GitLogParser.CommitFiles> commitHistory =
+                GitLogParser.parseCommitFiles(repoRoot, sinceDays);
+        System.out.println(summary("Commits analysed: ", String.valueOf(commitHistory.size())));
+
+        // ---- co-change ----
+        System.out.println(phase("Computing co-change frequencies (threshold=" + threshold + ")..."));
+        Map<String, List<CoChangeAnalyzer.CoChangeEntry>> coChanges =
+                CoChangeAnalyzer.analyze(commitHistory, threshold);
+
+        Path coChangesFile = resolvedStateDir.resolve("co-changes.json");
+        writeCoChanges(coChangesFile, coChanges, sinceDays, threshold);
+        System.out.println(summary("Co-change pairs : ", String.valueOf(coChanges.size())));
+        System.out.println(summary("Written         : ", coChangesFile.toString()));
+
+        // ---- ownership ----
+        System.out.println(phase("Computing file ownership (last 90 days)..."));
+        List<GitLogParser.CommitFiles> authorHistory =
+                GitLogParser.parseAuthorFiles(repoRoot, Math.min(sinceDays, 90));
+        Map<String, String> ownership = OwnershipAnalyzer.analyze(authorHistory);
+
+        Path ownershipFile = resolvedStateDir.resolve("ownership.json");
+        writeOwnership(ownershipFile, ownership, Math.min(sinceDays, 90));
+        System.out.println(summary("Files with owner: ", String.valueOf(ownership.size())));
+        System.out.println(summary("Written         : ", ownershipFile.toString()));
+
+        long elapsedMs = (System.nanoTime() - start) / 1_000_000;
+        System.out.println(summary("Total time      : ", elapsedMs + "ms"));
+        return 0;
+    }
+
+    private static void writeCoChanges(Path path,
+            Map<String, List<CoChangeAnalyzer.CoChangeEntry>> coChanges,
+            int sinceDays, int threshold) throws IOException {
+        List<Map<String, Object>> entries = new ArrayList<>();
+        coChanges.entrySet().stream()
+                .sorted(Comparator.comparingInt(
+                        (Map.Entry<String, List<CoChangeAnalyzer.CoChangeEntry>> e) ->
+                                e.getValue().stream().mapToInt(CoChangeAnalyzer.CoChangeEntry::frequency).sum())
+                        .reversed())
+                .forEach(entry -> {
+                    List<Map<String, Object>> partners = entry.getValue().stream()
+                            .map(p -> Map.<String, Object>of("file", p.file(), "frequency", p.frequency()))
+                            .toList();
+                    entries.add(Map.of("file", entry.getKey(), "coChangedWith", partners));
+                });
+
+        Map<String, Object> payload = Map.of(
+                "schemaVersion", 1,
+                "generatedAt", Instant.now().toString(),
+                "sinceDays", sinceDays,
+                "threshold", threshold,
+                "entries", entries);
+
+        try (OutputStream out = Files.newOutputStream(path)) {
+            MAPPER.writeValue(out, payload);
+        }
+    }
+
+    private static void writeOwnership(Path path, Map<String, String> ownership,
+            int sinceDays) throws IOException {
+        List<Map<String, String>> entries = ownership.entrySet().stream()
+                .sorted(Map.Entry.comparingByKey())
+                .map(e -> Map.of("file", e.getKey(), "owner", e.getValue()))
+                .toList();
+
+        Map<String, Object> payload = Map.of(
+                "schemaVersion", 1,
+                "generatedAt", Instant.now().toString(),
+                "sinceDays", sinceDays,
+                "entries", entries);
+
+        try (OutputStream out = Files.newOutputStream(path)) {
+            MAPPER.writeValue(out, payload);
+        }
+    }
+
+    private static String phase(String value) {
+        return Ansi.style(value, Ansi.BOLD);
+    }
+
+    private static String summary(String label, String value) {
+        return label + Ansi.style(value, Ansi.BOLD, Ansi.GREEN);
+    }
+}

--- a/graphus-cli/src/main/java/io/graphus/cli/GraphusCommand.java
+++ b/graphus-cli/src/main/java/io/graphus/cli/GraphusCommand.java
@@ -1,6 +1,10 @@
 package io.graphus.cli;
 
 import io.graphus.cli.install.InstallCommand;
+import io.graphus.cli.GitAnalyzeCommand;
+import io.graphus.cli.HotspotsCommand;
+import io.graphus.cli.SnapshotCommand;
+import io.graphus.cli.DriftCommand;
 import io.graphus.indexer.EmbeddingBackend;
 import io.graphus.indexer.EmbeddingModelFactory;
 import io.graphus.indexer.FileChangeSet;
@@ -41,7 +45,11 @@ import picocli.CommandLine.Parameters;
                 GraphusCommand.SyncCommand.class,
                 GraphusCommand.QueryCommand.class,
                 GraphusCommand.BlastRadiusCommand.class,
-                InstallCommand.class
+                InstallCommand.class,
+                GitAnalyzeCommand.class,
+                HotspotsCommand.class,
+                SnapshotCommand.class,
+                DriftCommand.class
         },
         description = "Java/Spring code graph + RAG CLI"
 )

--- a/graphus-cli/src/main/java/io/graphus/cli/HotspotsCommand.java
+++ b/graphus-cli/src/main/java/io/graphus/cli/HotspotsCommand.java
@@ -1,0 +1,150 @@
+package io.graphus.cli;
+
+import io.graphus.cli.git.ChurnAnalyzer;
+import io.graphus.cli.git.GitLogParser;
+import io.graphus.model.CallEdge;
+import io.graphus.model.ClassNode;
+import io.graphus.model.SymbolNode;
+import io.graphus.parser.ProjectParser;
+import io.graphus.parser.ProjectParserResult;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.Callable;
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Option;
+
+/**
+ * Ranks files by {@code churn × coupling} — git commit frequency multiplied by the number of
+ * distinct callers in the call graph. High scores identify files that change often and are
+ * heavily depended upon — the riskiest places to touch.
+ */
+@Command(name = "hotspots",
+        description = "Rank files by churn × coupling to identify high-risk change targets")
+public final class HotspotsCommand implements Callable<Integer> {
+
+    @Option(names = "--repo", defaultValue = ".", description = "Repository root path")
+    private Path repositoryRoot;
+
+    @Option(names = "--source",
+            description = "Java/Kotlin source root; can be passed multiple times")
+    private List<Path> sourceRoots = new ArrayList<>();
+
+    @Option(names = "--since", defaultValue = "365",
+            description = "Look back N days for git churn (0 = all history)")
+    private int sinceDays;
+
+    @Option(names = "--top", defaultValue = "20",
+            description = "Number of hotspot entries to display")
+    private int top;
+
+    @Override
+    public Integer call() throws Exception {
+        long start = System.nanoTime();
+        Path repoRoot = repositoryRoot.toAbsolutePath().normalize();
+
+        // ---- git churn ----
+        System.out.println(phase("Mining git churn (last " + sinceDays + " days)..."));
+        List<GitLogParser.CommitFiles> history =
+                GitLogParser.parseCommitFiles(repoRoot, sinceDays);
+        Map<String, Integer> churn = ChurnAnalyzer.analyze(history);
+        System.out.println(summary("Files with churn : ", String.valueOf(churn.size())));
+
+        // ---- call graph coupling ----
+        System.out.println(phase("Parsing call graph for coupling..."));
+        List<io.graphus.model.WorkspaceDescriptor> workspaces =
+                CliWorkspaceLayouts.resolve(repoRoot, sourceRoots);
+        if (workspaces.isEmpty()) {
+            System.err.println(Ansi.style("No analysable workspace found.", Ansi.BOLD, Ansi.RED));
+            return 1;
+        }
+
+        ProjectParser projectParser = new ProjectParser();
+        ParserProgressReporter reporter = new ParserProgressReporter();
+        ProjectParserResult parseResult = projectParser.parse(workspaces.get(0), reporter);
+        reporter.complete();
+
+        Map<String, Integer> couplingByFile = computeFileCoupling(parseResult, repoRoot);
+        System.out.println(summary("Files with callers: ", String.valueOf(couplingByFile.size())));
+
+        // ---- rank ----
+        List<HotspotEntry> hotspots = new ArrayList<>();
+        Set<String> allFiles = new HashSet<>(churn.keySet());
+        allFiles.addAll(couplingByFile.keySet());
+
+        for (String file : allFiles) {
+            int fileChurn = churn.getOrDefault(file, 0);
+            int coupling = couplingByFile.getOrDefault(file, 0);
+            if (fileChurn > 0 || coupling > 0) {
+                hotspots.add(new HotspotEntry(file, fileChurn, coupling, (long) fileChurn * coupling));
+            }
+        }
+
+        hotspots.sort((a, b) -> Long.compare(b.score(), a.score()));
+
+        // ---- output ----
+        int count = Math.min(top, hotspots.size());
+        System.out.println(phase("\nTop " + count + " hotspots (churn × coupling):"));
+        System.out.println(Ansi.style(
+                String.format("%-6s %-6s %-6s %s", "SCORE", "CHURN", "CALLERS", "FILE"),
+                Ansi.DIM));
+
+        for (int i = 0; i < count; i++) {
+            HotspotEntry e = hotspots.get(i);
+            String line = String.format("%-6d %-6d %-6d %s",
+                    e.score(), e.churn(), e.coupling(), e.file());
+            System.out.println(Ansi.style("[" + (i + 1) + "]", Ansi.CYAN) + " " + line);
+        }
+
+        long elapsedMs = (System.nanoTime() - start) / 1_000_000;
+        System.out.println(summary("\nTotal time: ", elapsedMs + "ms"));
+        return 0;
+    }
+
+    /**
+     * Counts distinct files that have at least one edge pointing to any node in the target file.
+     * Repository-relative paths are used as keys to match git output.
+     */
+    private static Map<String, Integer> computeFileCoupling(
+            ProjectParserResult result, Path repoRoot) {
+        Map<String, Set<String>> callerFilesByTargetFile = new HashMap<>();
+
+        for (CallEdge edge : result.callGraph().getEdges()) {
+            SymbolNode toNode = result.callGraph().getNode(edge.toId());
+            SymbolNode fromNode = result.callGraph().getNode(edge.fromId());
+            if (toNode == null || fromNode == null) {
+                continue;
+            }
+            String targetFile = toNode.getFilePath();
+            String callerFile = fromNode.getFilePath();
+            if (targetFile == null || targetFile.isBlank()
+                    || callerFile == null || callerFile.isBlank()
+                    || targetFile.equals(callerFile)) {
+                continue;
+            }
+            callerFilesByTargetFile
+                    .computeIfAbsent(targetFile, k -> new HashSet<>())
+                    .add(callerFile);
+        }
+
+        Map<String, Integer> coupling = new HashMap<>();
+        for (Map.Entry<String, Set<String>> entry : callerFilesByTargetFile.entrySet()) {
+            coupling.put(entry.getKey(), entry.getValue().size());
+        }
+        return coupling;
+    }
+
+    private record HotspotEntry(String file, int churn, int coupling, long score) {}
+
+    private static String phase(String value) {
+        return Ansi.style(value, Ansi.BOLD);
+    }
+
+    private static String summary(String label, String value) {
+        return label + Ansi.style(value, Ansi.BOLD, Ansi.GREEN);
+    }
+}

--- a/graphus-cli/src/main/java/io/graphus/cli/SnapshotCommand.java
+++ b/graphus-cli/src/main/java/io/graphus/cli/SnapshotCommand.java
@@ -1,0 +1,161 @@
+package io.graphus.cli;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import io.graphus.model.CallEdge;
+import io.graphus.model.CallGraph;
+import io.graphus.model.ModuleNode;
+import io.graphus.model.SymbolKind;
+import io.graphus.model.SymbolNode;
+import io.graphus.parser.ProjectParser;
+import io.graphus.parser.ProjectParserResult;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.Callable;
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Option;
+
+/**
+ * Serializes a point-in-time snapshot of the call-graph statistics to
+ * {@code .graphus/snapshots/<timestamp>.json}. Use {@code graphus drift} to compare two snapshots.
+ */
+@Command(name = "snapshot",
+        description = "Capture a point-in-time snapshot of the call graph for drift detection")
+public final class SnapshotCommand implements Callable<Integer> {
+
+    private static final ObjectMapper MAPPER =
+            new ObjectMapper().enable(SerializationFeature.INDENT_OUTPUT);
+    private static final DateTimeFormatter TIMESTAMP_FMT =
+            DateTimeFormatter.ofPattern("yyyyMMdd'T'HHmmss'Z'").withZone(ZoneOffset.UTC);
+
+    @Option(names = "--repo", defaultValue = ".", description = "Repository root path")
+    private Path repositoryRoot;
+
+    @Option(names = "--source",
+            description = "Java/Kotlin source root; can be passed multiple times")
+    private List<Path> sourceRoots = new ArrayList<>();
+
+    @Option(names = "--state-dir",
+            description = "Directory under which the snapshots/ folder is created (default: .graphus)")
+    private Path stateDir;
+
+    @Option(names = "--label",
+            description = "Optional human-readable label stored in the snapshot (e.g. 'before-refactor')")
+    private String label;
+
+    @Override
+    public Integer call() throws Exception {
+        long start = System.nanoTime();
+        Path repoRoot = repositoryRoot.toAbsolutePath().normalize();
+        Path resolvedStateDir = stateDir != null
+                ? stateDir.toAbsolutePath().normalize()
+                : repoRoot.resolve(".graphus").normalize();
+        Path snapshotsDir = resolvedStateDir.resolve("snapshots");
+        Files.createDirectories(snapshotsDir);
+
+        System.out.println(phase("Parsing call graph for snapshot..."));
+        List<io.graphus.model.WorkspaceDescriptor> workspaces =
+                CliWorkspaceLayouts.resolve(repoRoot, sourceRoots);
+        if (workspaces.isEmpty()) {
+            System.err.println(Ansi.style("No analysable workspace found.", Ansi.BOLD, Ansi.RED));
+            return 1;
+        }
+
+        ProjectParser projectParser = new ProjectParser();
+        ParserProgressReporter reporter = new ParserProgressReporter();
+        ProjectParserResult result = projectParser.parse(workspaces.get(0), reporter);
+        reporter.complete();
+        CallGraph callGraph = result.callGraph();
+
+        System.out.println(phase("Computing statistics..."));
+        Map<String, Object> snapshot = buildSnapshot(callGraph, repoRoot, label, result);
+
+        String timestamp = TIMESTAMP_FMT.format(Instant.now());
+        String filename = label != null && !label.isBlank()
+                ? timestamp + "-" + label.replaceAll("[^a-zA-Z0-9_-]", "-") + ".json"
+                : timestamp + ".json";
+        Path snapshotFile = snapshotsDir.resolve(filename);
+
+        try (OutputStream out = Files.newOutputStream(snapshotFile)) {
+            MAPPER.writeValue(out, snapshot);
+        }
+
+        long elapsedMs = (System.nanoTime() - start) / 1_000_000;
+        System.out.println(summary("Snapshot written: ", snapshotFile.toString()));
+        System.out.println(summary("Total time      : ", elapsedMs + "ms"));
+        return 0;
+    }
+
+    static Map<String, Object> buildSnapshot(CallGraph callGraph, Path repoRoot,
+            String label, ProjectParserResult result) {
+        // node counts by kind
+        Map<String, Integer> nodesByKind = new HashMap<>();
+        for (SymbolNode node : callGraph.getNodes()) {
+            nodesByKind.merge(node.getKind().name(), 1, Integer::sum);
+        }
+
+        // top coupled nodes (by incoming edge count)
+        Map<String, Integer> incomingCount = new HashMap<>();
+        for (CallEdge edge : callGraph.getEdges()) {
+            incomingCount.merge(edge.toId(), 1, Integer::sum);
+        }
+        List<Map<String, Object>> topCoupled = incomingCount.entrySet().stream()
+                .sorted(Map.Entry.<String, Integer>comparingByValue().reversed())
+                .limit(10)
+                .map(e -> Map.<String, Object>of("id", e.getKey(), "incomingEdges", e.getValue()))
+                .toList();
+
+        // file count
+        Set<String> files = new HashSet<>();
+        for (SymbolNode node : callGraph.getNodes()) {
+            if (node.getFilePath() != null && !node.getFilePath().isBlank()) {
+                files.add(node.getFilePath());
+            }
+        }
+
+        // module list
+        List<String> modules = callGraph.getNodes().stream()
+                .filter(n -> n instanceof ModuleNode)
+                .map(n -> ((ModuleNode) n).getModuleName())
+                .sorted()
+                .toList();
+
+        Map<String, Object> snapshot = new java.util.LinkedHashMap<>();
+        snapshot.put("schemaVersion", 1);
+        snapshot.put("createdAt", Instant.now().toString());
+        snapshot.put("repoRoot", repoRoot.toString());
+        if (label != null && !label.isBlank()) {
+            snapshot.put("label", label);
+        }
+        snapshot.put("parsedFiles", result.parsedFiles());
+        snapshot.put("unresolvedCalls", result.unresolvedCalls());
+        snapshot.put("totalNodes", callGraph.getNodes().size());
+        snapshot.put("totalEdges", callGraph.getEdges().size());
+        snapshot.put("totalFiles", files.size());
+        snapshot.put("nodesByKind", nodesByKind);
+        snapshot.put("moduleCount", modules.size());
+        snapshot.put("modules", modules);
+        snapshot.put("topCoupledNodes", topCoupled);
+        return snapshot;
+    }
+
+    private static String phase(String value) {
+        return Ansi.style(value, Ansi.BOLD);
+    }
+
+    private static String summary(String label, String value) {
+        return label + Ansi.style(value, Ansi.BOLD, Ansi.GREEN);
+    }
+}

--- a/graphus-cli/src/main/java/io/graphus/cli/git/ChurnAnalyzer.java
+++ b/graphus-cli/src/main/java/io/graphus/cli/git/ChurnAnalyzer.java
@@ -1,0 +1,29 @@
+package io.graphus.cli.git;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Computes per-file commit churn (number of commits that touched the file) from git history.
+ */
+public final class ChurnAnalyzer {
+
+    private ChurnAnalyzer() {
+    }
+
+    /**
+     * @param history commits and their changed files, as produced by {@link GitLogParser}
+     * @return map of file path → commit count, in no particular order
+     */
+    public static Map<String, Integer> analyze(List<GitLogParser.CommitFiles> history) {
+        Map<String, Integer> churn = new HashMap<>();
+        for (GitLogParser.CommitFiles commit : history) {
+            for (String file : commit.files()) {
+                churn.merge(file, 1, Integer::sum);
+            }
+        }
+        return Collections.unmodifiableMap(churn);
+    }
+}

--- a/graphus-cli/src/main/java/io/graphus/cli/git/CoChangeAnalyzer.java
+++ b/graphus-cli/src/main/java/io/graphus/cli/git/CoChangeAnalyzer.java
@@ -1,0 +1,63 @@
+package io.graphus.cli.git;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Computes per-file co-change frequency from a parsed git commit history.
+ *
+ * <p>For each commit, every pair of changed files is counted. File pairs whose
+ * co-change count exceeds the given threshold are included in the result.
+ * Files that only appear alone in commits (no pair partner) are not included.
+ */
+public final class CoChangeAnalyzer {
+
+    private CoChangeAnalyzer() {
+    }
+
+    /**
+     * @param history   commits and their changed files, as produced by {@link GitLogParser}
+     * @param threshold minimum co-change count for a pair to be included
+     * @return map of file → co-changed partners, sorted by frequency descending; only entries
+     *         where at least one partner meets the threshold are included
+     */
+    public static Map<String, List<CoChangeEntry>> analyze(
+            List<GitLogParser.CommitFiles> history, int threshold) {
+        Map<String, Map<String, Integer>> rawCounts = new HashMap<>();
+
+        for (GitLogParser.CommitFiles commit : history) {
+            List<String> files = commit.files();
+            for (int i = 0; i < files.size(); i++) {
+                for (int j = i + 1; j < files.size(); j++) {
+                    String a = files.get(i);
+                    String b = files.get(j);
+                    rawCounts.computeIfAbsent(a, k -> new HashMap<>())
+                            .merge(b, 1, Integer::sum);
+                    rawCounts.computeIfAbsent(b, k -> new HashMap<>())
+                            .merge(a, 1, Integer::sum);
+                }
+            }
+        }
+
+        Map<String, List<CoChangeEntry>> result = new HashMap<>();
+        for (Map.Entry<String, Map<String, Integer>> entry : rawCounts.entrySet()) {
+            List<CoChangeEntry> partners = new ArrayList<>();
+            for (Map.Entry<String, Integer> partner : entry.getValue().entrySet()) {
+                if (partner.getValue() >= threshold) {
+                    partners.add(new CoChangeEntry(partner.getKey(), partner.getValue()));
+                }
+            }
+            if (!partners.isEmpty()) {
+                partners.sort(Comparator.comparingInt(CoChangeEntry::frequency).reversed());
+                result.put(entry.getKey(), Collections.unmodifiableList(partners));
+            }
+        }
+        return Collections.unmodifiableMap(result);
+    }
+
+    public record CoChangeEntry(String file, int frequency) {}
+}

--- a/graphus-cli/src/main/java/io/graphus/cli/git/GitLogParser.java
+++ b/graphus-cli/src/main/java/io/graphus/cli/git/GitLogParser.java
@@ -1,0 +1,94 @@
+package io.graphus.cli.git;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Runs {@code git log} as a subprocess and parses the output into per-commit file lists.
+ * Uses {@code --format=format:COMMIT:%H} so commit boundaries are clearly delimited,
+ * with {@code --name-only} to list the files changed in each commit.
+ */
+public final class GitLogParser {
+
+    private static final String COMMIT_PREFIX = "COMMIT:";
+    private static final String AUTHOR_PREFIX = "AUTHOR:";
+
+    private GitLogParser() {
+    }
+
+    /**
+     * Returns one {@link CommitFiles} entry per commit, in reverse-chronological order.
+     *
+     * @param repoRoot  the git repository root
+     * @param sinceDays only include commits from the last N days (0 = all history)
+     */
+    public static List<CommitFiles> parseCommitFiles(Path repoRoot, int sinceDays) throws IOException {
+        List<String> cmd = new ArrayList<>(List.of(
+                "git", "log", "--name-only", "--format=format:COMMIT:%H", "--diff-filter=d"));
+        if (sinceDays > 0) {
+            cmd.add("--since=" + sinceDays + ".days");
+        }
+        return parseCommitBlocks(repoRoot, cmd, COMMIT_PREFIX);
+    }
+
+    /**
+     * Returns one {@link CommitFiles} entry per commit where the header field is the author email.
+     * Used by {@link OwnershipAnalyzer} to attribute files to their most-active author.
+     *
+     * @param repoRoot  the git repository root
+     * @param sinceDays only include commits from the last N days (0 = all history)
+     */
+    public static List<CommitFiles> parseAuthorFiles(Path repoRoot, int sinceDays) throws IOException {
+        List<String> cmd = new ArrayList<>(List.of(
+                "git", "log", "--name-only", "--format=format:AUTHOR:%ae", "--diff-filter=d"));
+        if (sinceDays > 0) {
+            cmd.add("--since=" + sinceDays + ".days");
+        }
+        return parseCommitBlocks(repoRoot, cmd, AUTHOR_PREFIX);
+    }
+
+    private static List<CommitFiles> parseCommitBlocks(Path repoRoot, List<String> cmd,
+            String headerPrefix) throws IOException {
+        Process process = new ProcessBuilder(cmd)
+                .directory(repoRoot.toFile())
+                .redirectErrorStream(false)
+                .start();
+
+        List<CommitFiles> result = new ArrayList<>();
+        String currentHeader = null;
+        List<String> currentFiles = new ArrayList<>();
+
+        try (BufferedReader reader = new BufferedReader(
+                new InputStreamReader(process.getInputStream(), StandardCharsets.UTF_8))) {
+            String line;
+            while ((line = reader.readLine()) != null) {
+                if (line.startsWith(headerPrefix)) {
+                    if (currentHeader != null && !currentFiles.isEmpty()) {
+                        result.add(new CommitFiles(currentHeader, List.copyOf(currentFiles)));
+                    }
+                    currentHeader = line.substring(headerPrefix.length());
+                    currentFiles = new ArrayList<>();
+                } else if (!line.isBlank() && currentHeader != null) {
+                    currentFiles.add(line.trim());
+                }
+            }
+        }
+        if (currentHeader != null && !currentFiles.isEmpty()) {
+            result.add(new CommitFiles(currentHeader, List.copyOf(currentFiles)));
+        }
+
+        try {
+            process.waitFor();
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
+        return List.copyOf(result);
+    }
+
+    public record CommitFiles(String header, List<String> files) {}
+}

--- a/graphus-cli/src/main/java/io/graphus/cli/git/OwnershipAnalyzer.java
+++ b/graphus-cli/src/main/java/io/graphus/cli/git/OwnershipAnalyzer.java
@@ -1,0 +1,50 @@
+package io.graphus.cli.git;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Determines the primary owner of each file based on who has the most commits touching it
+ * within the analysed window. Uses author email as the owner identifier.
+ *
+ * <p>When a {@code CODEOWNERS} file is present it should take precedence; this class covers
+ * the common case where no CODEOWNERS file exists.
+ */
+public final class OwnershipAnalyzer {
+
+    private OwnershipAnalyzer() {
+    }
+
+    /**
+     * @param authorHistory commits parsed with author email as the header field,
+     *                      as produced by {@link GitLogParser#parseAuthorFiles}
+     * @return map of file path → primary author email (author with the most commits in the window)
+     */
+    public static Map<String, String> analyze(List<GitLogParser.CommitFiles> authorHistory) {
+        Map<String, Map<String, Integer>> countsByFile = new HashMap<>();
+        for (GitLogParser.CommitFiles commit : authorHistory) {
+            String author = commit.header();
+            if (author == null || author.isBlank()) {
+                continue;
+            }
+            for (String file : commit.files()) {
+                countsByFile.computeIfAbsent(file, k -> new HashMap<>())
+                        .merge(author, 1, Integer::sum);
+            }
+        }
+
+        Map<String, String> ownership = new HashMap<>();
+        for (Map.Entry<String, Map<String, Integer>> entry : countsByFile.entrySet()) {
+            String primaryOwner = entry.getValue().entrySet().stream()
+                    .max(Map.Entry.comparingByValue())
+                    .map(Map.Entry::getKey)
+                    .orElse(null);
+            if (primaryOwner != null) {
+                ownership.put(entry.getKey(), primaryOwner);
+            }
+        }
+        return Collections.unmodifiableMap(ownership);
+    }
+}

--- a/graphus-cli/src/test/java/io/graphus/cli/git/ChurnAnalyzerTest.java
+++ b/graphus-cli/src/test/java/io/graphus/cli/git/ChurnAnalyzerTest.java
@@ -1,0 +1,43 @@
+package io.graphus.cli.git;
+
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class ChurnAnalyzerTest {
+
+    @Test
+    void countsCommitsPerFile() {
+        List<GitLogParser.CommitFiles> history = List.of(
+                commit("A.java", "B.java"),
+                commit("A.java"),
+                commit("B.java", "C.java"));
+
+        Map<String, Integer> result = ChurnAnalyzer.analyze(history);
+
+        assertEquals(2, result.get("A.java"));
+        assertEquals(2, result.get("B.java"));
+        assertEquals(1, result.get("C.java"));
+    }
+
+    @Test
+    void emptyHistoryReturnsEmptyMap() {
+        assertTrue(ChurnAnalyzer.analyze(List.of()).isEmpty());
+    }
+
+    @Test
+    void singleFileInSingleCommit() {
+        Map<String, Integer> result =
+                ChurnAnalyzer.analyze(List.of(commit("Only.java")));
+
+        assertEquals(1, result.get("Only.java"));
+        assertEquals(1, result.size());
+    }
+
+    private static GitLogParser.CommitFiles commit(String... files) {
+        return new GitLogParser.CommitFiles("hash", List.of(files));
+    }
+}

--- a/graphus-cli/src/test/java/io/graphus/cli/git/CoChangeAnalyzerTest.java
+++ b/graphus-cli/src/test/java/io/graphus/cli/git/CoChangeAnalyzerTest.java
@@ -1,0 +1,95 @@
+package io.graphus.cli.git;
+
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class CoChangeAnalyzerTest {
+
+    @Test
+    void pairsAboveThresholdAreIncluded() {
+        List<GitLogParser.CommitFiles> history = List.of(
+                commit("A.java", "B.java"),
+                commit("A.java", "B.java"),
+                commit("A.java", "B.java"));
+
+        Map<String, List<CoChangeAnalyzer.CoChangeEntry>> result =
+                CoChangeAnalyzer.analyze(history, 2);
+
+        assertTrue(result.containsKey("A.java"));
+        assertEquals(1, result.get("A.java").size());
+        assertEquals("B.java", result.get("A.java").get(0).file());
+        assertEquals(3, result.get("A.java").get(0).frequency());
+    }
+
+    @Test
+    void pairsBelowThresholdAreExcluded() {
+        List<GitLogParser.CommitFiles> history = List.of(
+                commit("A.java", "B.java"),
+                commit("A.java", "B.java"));
+
+        Map<String, List<CoChangeAnalyzer.CoChangeEntry>> result =
+                CoChangeAnalyzer.analyze(history, 5);
+
+        assertTrue(result.isEmpty());
+    }
+
+    @Test
+    void soloFilesNotIncluded() {
+        List<GitLogParser.CommitFiles> history = List.of(
+                commit("A.java"),
+                commit("A.java"),
+                commit("A.java"));
+
+        Map<String, List<CoChangeAnalyzer.CoChangeEntry>> result =
+                CoChangeAnalyzer.analyze(history, 1);
+
+        assertFalse(result.containsKey("A.java"));
+    }
+
+    @Test
+    void partnersAreSortedByFrequencyDescending() {
+        List<GitLogParser.CommitFiles> history = List.of(
+                commit("A.java", "B.java", "C.java"),
+                commit("A.java", "C.java"),
+                commit("A.java", "C.java"),
+                commit("A.java", "B.java"));
+
+        Map<String, List<CoChangeAnalyzer.CoChangeEntry>> result =
+                CoChangeAnalyzer.analyze(history, 1);
+
+        List<CoChangeAnalyzer.CoChangeEntry> partners = result.get("A.java");
+        assertEquals("C.java", partners.get(0).file()); // freq=3
+        assertEquals("B.java", partners.get(1).file()); // freq=2
+    }
+
+    @Test
+    void relationshipIsSymmetric() {
+        List<GitLogParser.CommitFiles> history = List.of(
+                commit("A.java", "B.java"),
+                commit("A.java", "B.java"));
+
+        Map<String, List<CoChangeAnalyzer.CoChangeEntry>> result =
+                CoChangeAnalyzer.analyze(history, 1);
+
+        assertTrue(result.containsKey("A.java"));
+        assertTrue(result.containsKey("B.java"));
+        assertEquals("B.java", result.get("A.java").get(0).file());
+        assertEquals("A.java", result.get("B.java").get(0).file());
+    }
+
+    @Test
+    void emptyHistoryReturnsEmptyMap() {
+        assertTrue(CoChangeAnalyzer.analyze(List.of(), 1).isEmpty());
+    }
+
+    // ---- helpers ----
+
+    private static GitLogParser.CommitFiles commit(String... files) {
+        return new GitLogParser.CommitFiles("hash-" + System.nanoTime(), List.of(files));
+    }
+}

--- a/graphus-cli/src/test/java/io/graphus/cli/git/OwnershipAnalyzerTest.java
+++ b/graphus-cli/src/test/java/io/graphus/cli/git/OwnershipAnalyzerTest.java
@@ -1,0 +1,58 @@
+package io.graphus.cli.git;
+
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class OwnershipAnalyzerTest {
+
+    @Test
+    void primaryOwnerIsMostFrequentAuthor() {
+        List<GitLogParser.CommitFiles> history = List.of(
+                authorCommit("alice@example.com", "Service.java"),
+                authorCommit("alice@example.com", "Service.java"),
+                authorCommit("bob@example.com", "Service.java"));
+
+        Map<String, String> result = OwnershipAnalyzer.analyze(history);
+
+        assertEquals("alice@example.com", result.get("Service.java"));
+    }
+
+    @Test
+    void eachFileGetsItsOwnOwner() {
+        List<GitLogParser.CommitFiles> history = List.of(
+                authorCommit("alice@example.com", "A.java", "B.java"),
+                authorCommit("bob@example.com", "B.java", "C.java"),
+                authorCommit("bob@example.com", "B.java"));
+
+        Map<String, String> result = OwnershipAnalyzer.analyze(history);
+
+        assertEquals("alice@example.com", result.get("A.java"));
+        assertEquals("bob@example.com", result.get("B.java")); // bob has 2 vs alice 1
+        assertEquals("bob@example.com", result.get("C.java"));
+    }
+
+    @Test
+    void blankAuthorIsIgnored() {
+        List<GitLogParser.CommitFiles> history = List.of(
+                authorCommit("", "A.java"),
+                authorCommit("  ", "A.java"),
+                authorCommit("alice@example.com", "A.java"));
+
+        Map<String, String> result = OwnershipAnalyzer.analyze(history);
+
+        assertEquals("alice@example.com", result.get("A.java"));
+    }
+
+    @Test
+    void emptyHistoryReturnsEmptyMap() {
+        assertTrue(OwnershipAnalyzer.analyze(List.of()).isEmpty());
+    }
+
+    private static GitLogParser.CommitFiles authorCommit(String author, String... files) {
+        return new GitLogParser.CommitFiles(author, List.of(files));
+    }
+}


### PR DESCRIPTION
## Summary

- **`graphus git-analyze`** — mines `git log` (configurable `--since` window, default 365 days) to compute per-file co-change frequencies and primary ownership; writes `.graphus/co-changes.json` and `.graphus/ownership.json`. Smoke-tested on pmp-core: 874 commits → 224 co-change pairs, 1,910 files with owners, in 1s.
- **`graphus hotspots`** — re-parses the call graph and combines with git churn to rank files by `churn × coupling`; outputs a ranked table with score, commit count, and caller count per file
- **`graphus snapshot`** — serializes node/edge statistics (by kind), top-10 coupled nodes, module list, and unresolved call count to `.graphus/snapshots/<timestamp>.json` for drift tracking
- **`graphus drift <a> <b>`** — diffs two snapshot files and reports counter deltas, module additions/removals, and coupling changes with color-coded output

Shared git parsing layer (`io.graphus.cli.git`): `GitLogParser`, `CoChangeAnalyzer`, `ChurnAnalyzer`, `OwnershipAnalyzer` — all independently unit-tested.

## Test plan

- [ ] 13 unit tests pass: `CoChangeAnalyzerTest` (6), `ChurnAnalyzerTest` (3), `OwnershipAnalyzerTest` (4)
- [ ] `./gradlew build` passes
- [ ] `git-analyze` smoke-tested on pmp-core ✅

Related to #70