### PR TITLE
feat(mcp): add MCP server with 7 code intelligence tools

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,7 +16,7 @@ Graphus is a Java CLI that parses Java and Kotlin + Spring Boot source code, bui
 | `graphus-model`   | Language-agnostic domain model — `CallGraph`, `SymbolNode`, `SpringMetadata`, `GuiceMetadata`                  |
 | `graphus-parser`  | Java (JavaParser) + Kotlin (`kotlin-compiler-embeddable` PSI) AST pipeline → `CallGraph` + cross-language pass |
 | `graphus-indexer` | LangChain4j `EmbeddingStore` (Chroma or SQLite), checksum sync over `.java` + `.kt` files, `config.json`       |
-| `graphus-cli`     | Picocli entry point — `index`, `sync`, `query`, `blast-radius`, `install`                                      |
+| `graphus-cli`     | Picocli entry point — `index`, `sync`, `query`, `blast-radius`, `install`, `serve`                             |
 
 See [Architecture](docs/architecture.md) for full class breakdown and data flow.
 
@@ -29,6 +29,7 @@ See [Architecture](docs/architecture.md) for full class breakdown and data flow.
 | `query`        | Natural language retrieval over indexed symbols                                        |
 | `blast-radius` | BFS traversal to find all callers of a symbol                                          |
 | `install`      | Write AI tool integration files (`claude-code`, `cursor`)                              |
+| `serve`        | Start an MCP server over STDIO for AI coding agents                                    |
 
 ```bash
 graphus <command> [options]

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Graphus is a Java CLI that parses Java and Kotlin + Spring Boot source code, bui
 - `graphus-model`: call graph and language-agnostic symbol domain model
 - `graphus-parser`: Java and Kotlin source parsing (JavaParser + Kotlin compiler PSI) and call graph construction, including the cross-language resolver
 - `graphus-indexer`: symbol chunk generation, LangChain4j `EmbeddingStore` integration (Chroma or SQLite), incremental sync via checksum registry (covers `.java` and `.kt` files), and `.graphus/config.json` persistence
-- `graphus-cli`: user-facing commands (`index`, `sync`, `query`, `blast-radius`, `install`)
+- `graphus-cli`: user-facing commands (`index`, `sync`, `query`, `blast-radius`, `install`, `serve`)
 
 ## Prerequisites
 
@@ -225,6 +225,25 @@ graphus query "where is user creation logic" --collection my-repo --embedding op
 `graphus index` / successful `sync` runs write **`{state-dir}/config.json`** with the resolved `{db,dbUrl,dbTimeoutSeconds?,dbFile?,embedding,collection}` so agents or Homebrew installs can rerun `sync`/`query` without repeating flags unless you intentionally override.
 
 Precedence whenever a flag is **omitted** on the CLI: **`config.json` → defaults** (`chroma` → `http://localhost:8000`, timeout `300`, embedding `local`, SQLite `<state-dir>/graphus.db`).
+
+## MCP Server
+
+After indexing, run `graphus install --tool claude-code` to register the MCP server automatically in `.claude/settings.local.json`.
+
+For manual setup, add to your MCP client settings:
+
+```json
+{
+  "mcpServers": {
+    "graphus": {
+      "command": "java",
+      "args": ["-jar", "/path/to/graphus.jar", "serve", "--repo", ".", "--db", "sqlite"]
+    }
+  }
+}
+```
+
+Available tools: `graphus_search`, `graphus_blast_radius`, `graphus_callers`, `graphus_callees`, `graphus_module_deps`, `graphus_hotspots`, `graphus_ownership`.
 
 ## Known Limitations
 

--- a/graphus-cli/build.gradle.kts
+++ b/graphus-cli/build.gradle.kts
@@ -42,6 +42,7 @@ dependencies {
     implementation("info.picocli:picocli:4.7.7")
     annotationProcessor("info.picocli:picocli-codegen:4.7.7")
     implementation("org.slf4j:slf4j-simple:2.0.17")
+    implementation("io.modelcontextprotocol.sdk:mcp:0.10.0")
 }
 
 application {

--- a/graphus-cli/build.gradle.kts
+++ b/graphus-cli/build.gradle.kts
@@ -43,6 +43,7 @@ dependencies {
     annotationProcessor("info.picocli:picocli-codegen:4.7.7")
     implementation("org.slf4j:slf4j-simple:2.0.17")
     implementation("io.modelcontextprotocol.sdk:mcp:0.10.0")
+    testImplementation("org.mockito:mockito-core:5.14.2")
 }
 
 application {

--- a/graphus-cli/src/main/java/io/graphus/cli/GraphusCommand.java
+++ b/graphus-cli/src/main/java/io/graphus/cli/GraphusCommand.java
@@ -3,6 +3,7 @@ package io.graphus.cli;
 import io.graphus.cli.install.InstallCommand;
 import io.graphus.cli.GitAnalyzeCommand;
 import io.graphus.cli.HotspotsCommand;
+import io.graphus.cli.ServeCommand;
 import io.graphus.cli.SnapshotCommand;
 import io.graphus.cli.DriftCommand;
 import io.graphus.indexer.EmbeddingBackend;
@@ -46,6 +47,7 @@ import picocli.CommandLine.Parameters;
                 GraphusCommand.QueryCommand.class,
                 GraphusCommand.BlastRadiusCommand.class,
                 InstallCommand.class,
+                ServeCommand.class,
                 GitAnalyzeCommand.class,
                 HotspotsCommand.class,
                 SnapshotCommand.class,

--- a/graphus-cli/src/main/java/io/graphus/cli/ServeCommand.java
+++ b/graphus-cli/src/main/java/io/graphus/cli/ServeCommand.java
@@ -1,0 +1,77 @@
+package io.graphus.cli;
+
+import io.graphus.cli.mcp.GraphusMcpContext;
+import io.graphus.cli.mcp.GraphusMcpServer;
+import io.modelcontextprotocol.server.McpSyncServer;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Properties;
+import java.util.concurrent.Callable;
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Option;
+
+@Command(
+        name = "serve",
+        description = "Start a Graphus MCP server over STDIO for use with AI coding agents (Claude Code, Cursor, Copilot)")
+public final class ServeCommand implements Callable<Integer> {
+
+    @Option(names = "--repo", defaultValue = ".", description = "Repository root path")
+    private Path repositoryRoot;
+
+    @Option(names = "--source", description = "Java or Kotlin source root; can be passed multiple times")
+    private List<Path> sourceRoots = new ArrayList<>();
+
+    @Option(names = "--state-dir", description = "Graphus state directory (default: .graphus)")
+    private Path stateDir;
+
+    @Option(names = "--db", description = "Vector store backend: chroma|sqlite")
+    private String db;
+
+    @Option(names = "--db-url", description = "Chroma base URL")
+    private String dbUrl;
+
+    @Option(names = "--db-timeout", description = "Chroma HTTP timeout in seconds")
+    private Integer dbTimeoutSeconds;
+
+    @Option(names = "--db-file", description = "SQLite database file path")
+    private String dbFile;
+
+    @Option(names = "--embedding", description = "Embedding backend: local|openai")
+    private String embeddingBackend;
+
+    @Override
+    public Integer call() throws Exception {
+        Path repoRoot = repositoryRoot.toAbsolutePath().normalize();
+        System.err.println("[graphus-mcp] Loading context from: " + repoRoot);
+
+        GraphusMcpContext ctx = GraphusMcpContext.load(
+                repoRoot, sourceRoots, stateDir, db, dbUrl, dbTimeoutSeconds, dbFile, embeddingBackend);
+
+        String version = resolveVersion();
+
+        System.err.println("[graphus-mcp] Starting MCP server v" + version + " on STDIO...");
+
+        McpSyncServer server = new GraphusMcpServer(ctx).build(version);
+        Runtime.getRuntime().addShutdownHook(new Thread(() -> {
+            System.err.println("[graphus-mcp] Shutting down.");
+            server.close();
+        }));
+
+        return 0;
+    }
+
+    private static String resolveVersion() {
+        Properties props = new Properties();
+        try (InputStream in = VersionProvider.class.getResourceAsStream("version.properties")) {
+            if (in != null) {
+                props.load(in);
+            }
+        } catch (IOException ignored) {
+            // fall through to default
+        }
+        return props.getProperty("version", "unknown");
+    }
+}

--- a/graphus-cli/src/main/java/io/graphus/cli/install/claudecode/ClaudeCodeAdapter.java
+++ b/graphus-cli/src/main/java/io/graphus/cli/install/claudecode/ClaudeCodeAdapter.java
@@ -4,6 +4,7 @@ import io.graphus.cli.install.ToolAdapter;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 
 public final class ClaudeCodeAdapter implements ToolAdapter {
 
@@ -32,6 +33,25 @@ public final class ClaudeCodeAdapter implements ToolAdapter {
 
         Path claudeMd = projectDir.resolve("CLAUDE.md");
         upsertGraphusSection(claudeMd);
+
+        Path graphusJar = resolveGraphusJar();
+        if (graphusJar != null) {
+            new ClaudeCodeMcpSettingsInstaller().install(projectDir, graphusJar);
+        } else {
+            System.err.println("[graphus] Warning: could not locate graphus.jar; skipping MCP server registration.");
+        }
+    }
+
+    private static Path resolveGraphusJar() {
+        try {
+            java.net.URI location = ClaudeCodeAdapter.class
+                    .getProtectionDomain().getCodeSource().getLocation().toURI();
+            Path jar = Paths.get(location);
+            if (jar.toString().endsWith(".jar")) {
+                return jar;
+            }
+        } catch (Exception ignored) {}
+        return null;
     }
 
     private static void write(Path path, String content) throws IOException {
@@ -64,7 +84,9 @@ public final class ClaudeCodeAdapter implements ToolAdapter {
                 <!-- graphus:start -->
                 ## Graphus
 
-                Graphus slash commands are available in `.claude/commands`:
+                Graphus MCP server is registered in `.claude/settings.local.json` — tools are available directly to Claude Code agents.
+
+                Graphus slash commands are also available in `.claude/commands`:
 
                 - `/project:graphus-index`
                 - `/project:graphus-sync`

--- a/graphus-cli/src/main/java/io/graphus/cli/install/claudecode/ClaudeCodeMcpSettingsInstaller.java
+++ b/graphus-cli/src/main/java/io/graphus/cli/install/claudecode/ClaudeCodeMcpSettingsInstaller.java
@@ -1,0 +1,41 @@
+package io.graphus.cli.install.claudecode;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+public final class ClaudeCodeMcpSettingsInstaller {
+
+    private static final ObjectMapper MAPPER =
+            new ObjectMapper().enable(SerializationFeature.INDENT_OUTPUT);
+
+    public void install(Path projectDir, Path graphusJar) throws IOException {
+        Path claudeDir = projectDir.resolve(".claude");
+        Files.createDirectories(claudeDir);
+        Path settingsFile = claudeDir.resolve("settings.local.json");
+
+        ObjectNode root = settingsFile.toFile().exists()
+                ? (ObjectNode) MAPPER.readTree(settingsFile.toFile())
+                : MAPPER.createObjectNode();
+
+        ObjectNode mcpServers = root.has("mcpServers")
+                ? (ObjectNode) root.get("mcpServers")
+                : root.putObject("mcpServers");
+
+        ObjectNode graphusServer = mcpServers.putObject("graphus");
+        graphusServer.put("command", "java");
+        graphusServer.putArray("args")
+                .add("-jar")
+                .add(graphusJar.toAbsolutePath().normalize().toString())
+                .add("serve")
+                .add("--repo")
+                .add(projectDir.toAbsolutePath().normalize().toString())
+                .add("--db")
+                .add("sqlite");
+
+        MAPPER.writeValue(settingsFile.toFile(), root);
+    }
+}

--- a/graphus-cli/src/main/java/io/graphus/cli/install/cursor/CursorAdapter.java
+++ b/graphus-cli/src/main/java/io/graphus/cli/install/cursor/CursorAdapter.java
@@ -77,6 +77,14 @@ public final class CursorAdapter implements ToolAdapter {
 
                 Use to identify callers that can impact a target symbol.
 
+                ### MCP Server
+
+                ```bash
+                graphus serve --repo . --db sqlite
+                ```
+
+                Starts an MCP server over STDIO for AI coding agents (Claude Code, Cursor, Copilot). After indexing, register automatically with `graphus install --tool claude-code` or `graphus install --tool cursor`.
+
                 ## Operating Guidelines
 
                 - `--collection` defaults to the repository/current directory name and can be omitted in most cases. Pass it explicitly only when targeting a collection with a different name.

--- a/graphus-cli/src/main/java/io/graphus/cli/mcp/GraphusMcpContext.java
+++ b/graphus-cli/src/main/java/io/graphus/cli/mcp/GraphusMcpContext.java
@@ -1,0 +1,107 @@
+package io.graphus.cli.mcp;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.graphus.cli.CliWorkspaceLayouts;
+import io.graphus.cli.ParserProgressReporter;
+import io.graphus.indexer.EmbeddingBackend;
+import io.graphus.indexer.EmbeddingModelFactory;
+import io.graphus.indexer.GraphIndexer;
+import io.graphus.indexer.GraphusConfigRegistry;
+import io.graphus.indexer.GraphusVectorRuntime;
+import io.graphus.indexer.VectorStoreFactory;
+import io.graphus.model.CallGraph;
+import io.graphus.model.WorkspaceDescriptor;
+import io.graphus.parser.ProjectParser;
+import io.graphus.parser.ProjectParserResult;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Locale;
+
+public final class GraphusMcpContext {
+
+    private final CallGraph callGraph;
+    private final GraphIndexer graphIndexer;
+    private final Path stateDir;
+    private final Path repoRoot;
+    private final ObjectMapper objectMapper;
+
+    private GraphusMcpContext(
+            CallGraph callGraph,
+            GraphIndexer graphIndexer,
+            Path stateDir,
+            Path repoRoot,
+            ObjectMapper objectMapper) {
+        this.callGraph = callGraph;
+        this.graphIndexer = graphIndexer;
+        this.stateDir = stateDir;
+        this.repoRoot = repoRoot;
+        this.objectMapper = objectMapper;
+    }
+
+    public static GraphusMcpContext load(
+            Path repoRoot,
+            List<Path> sourceRoots,
+            Path stateDir,
+            String db,
+            String dbUrl,
+            Integer dbTimeoutSeconds,
+            String dbFile,
+            String embeddingBackend) throws Exception {
+
+        Path normalizedRepo = repoRoot.toAbsolutePath().normalize();
+        Path normalizedState = stateDir != null
+                ? stateDir.toAbsolutePath().normalize()
+                : normalizedRepo.resolve(".graphus").normalize();
+
+        List<WorkspaceDescriptor> workspaces = CliWorkspaceLayouts.resolve(normalizedRepo, sourceRoots);
+        if (workspaces.isEmpty()) {
+            throw new IllegalStateException("No analysable workspace found under: " + normalizedRepo);
+        }
+        WorkspaceDescriptor workspace = workspaces.get(0);
+
+        System.err.println("[graphus-mcp] Parsing sources...");
+        ProjectParser parser = new ProjectParser();
+        ParserProgressReporter reporter = new ParserProgressReporter();
+        ProjectParserResult result = parser.parse(workspace, reporter);
+        reporter.complete();
+        System.err.println("[graphus-mcp] Parsed " + result.parsedFiles() + " files, " +
+                result.unresolvedCalls() + " unresolved calls.");
+
+        String persistedCollection = GraphusConfigRegistry.exists(normalizedState)
+                ? GraphusConfigRegistry.load(normalizedState).collection()
+                : normalizedRepo.getFileName().toString();
+
+        GraphusVectorRuntime.Resolved runtime = GraphusVectorRuntime.merge(
+                normalizedState,
+                persistedCollection,
+                db, dbUrl, dbTimeoutSeconds, dbFile, embeddingBackend);
+
+        EmbeddingBackend embBackend = parseEmbeddingBackend(runtime.embedding());
+        var embeddingModel = new EmbeddingModelFactory().create(embBackend);
+        var embeddingStore = VectorStoreFactory.create(runtime.backend(), runtime.storeConfig());
+        GraphIndexer graphIndexer = new GraphIndexer(embeddingModel, embeddingStore);
+
+        System.err.println("[graphus-mcp] Ready. CallGraph nodes=" + result.callGraph().getNodes().size());
+
+        return new GraphusMcpContext(
+                result.callGraph(),
+                graphIndexer,
+                normalizedState,
+                normalizedRepo,
+                new ObjectMapper());
+    }
+
+    public CallGraph callGraph() { return callGraph; }
+    public GraphIndexer graphIndexer() { return graphIndexer; }
+    public Path stateDir() { return stateDir; }
+    public Path repoRoot() { return repoRoot; }
+    public ObjectMapper objectMapper() { return objectMapper; }
+
+    private static EmbeddingBackend parseEmbeddingBackend(String value) {
+        String normalized = value == null ? "local" : value.toLowerCase(Locale.ROOT);
+        return switch (normalized) {
+            case "openai" -> EmbeddingBackend.OPENAI;
+            default -> EmbeddingBackend.LOCAL;
+        };
+    }
+}

--- a/graphus-cli/src/main/java/io/graphus/cli/mcp/GraphusMcpServer.java
+++ b/graphus-cli/src/main/java/io/graphus/cli/mcp/GraphusMcpServer.java
@@ -1,0 +1,44 @@
+package io.graphus.cli.mcp;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.graphus.cli.mcp.tools.BlastRadiusTool;
+import io.graphus.cli.mcp.tools.CalleesTool;
+import io.graphus.cli.mcp.tools.CallersTool;
+import io.graphus.cli.mcp.tools.HotspotsTool;
+import io.graphus.cli.mcp.tools.ModuleDepsTool;
+import io.graphus.cli.mcp.tools.OwnershipTool;
+import io.graphus.cli.mcp.tools.SearchTool;
+import io.modelcontextprotocol.server.McpServer;
+import io.modelcontextprotocol.server.McpSyncServer;
+import io.modelcontextprotocol.server.transport.StdioServerTransportProvider;
+import io.modelcontextprotocol.spec.McpSchema.ServerCapabilities;
+
+public final class GraphusMcpServer {
+
+    private final GraphusMcpContext ctx;
+
+    public GraphusMcpServer(GraphusMcpContext ctx) {
+        this.ctx = ctx;
+    }
+
+    public McpSyncServer build(String version) {
+        StdioServerTransportProvider transport = new StdioServerTransportProvider(new ObjectMapper());
+
+        ServerCapabilities capabilities = new ServerCapabilities.Builder()
+                .tools(Boolean.TRUE)
+                .build();
+
+        return McpServer.sync(transport)
+                .serverInfo("graphus", version)
+                .capabilities(capabilities)
+                .tools(
+                        new SearchTool(ctx).spec(),
+                        new BlastRadiusTool(ctx).spec(),
+                        new CallersTool(ctx).spec(),
+                        new CalleesTool(ctx).spec(),
+                        new ModuleDepsTool(ctx).spec(),
+                        new HotspotsTool(ctx).spec(),
+                        new OwnershipTool(ctx).spec())
+                .build();
+    }
+}

--- a/graphus-cli/src/main/java/io/graphus/cli/mcp/tools/BlastRadiusTool.java
+++ b/graphus-cli/src/main/java/io/graphus/cli/mcp/tools/BlastRadiusTool.java
@@ -1,0 +1,75 @@
+package io.graphus.cli.mcp.tools;
+
+import io.graphus.cli.mcp.GraphusMcpContext;
+import io.graphus.model.CallGraph;
+import io.graphus.model.SymbolNode;
+import io.modelcontextprotocol.server.McpServerFeatures.SyncToolSpecification;
+import io.modelcontextprotocol.spec.McpSchema.CallToolResult;
+import io.modelcontextprotocol.spec.McpSchema.Tool;
+import java.util.List;
+import java.util.Map;
+
+public final class BlastRadiusTool {
+
+    private static final String INPUT_SCHEMA = """
+            {"type":"object","properties":{"symbol":{"type":"string","description":"Fully qualified method ID or substring"},"depth":{"type":"integer","description":"Traversal depth (default 3)"}},"required":["symbol"]}
+            """;
+
+    private final GraphusMcpContext ctx;
+
+    public BlastRadiusTool(GraphusMcpContext ctx) {
+        this.ctx = ctx;
+    }
+
+    public SyncToolSpecification spec() {
+        Tool tool = new Tool(
+                "graphus_blast_radius",
+                "Find all callers of a symbol via BFS traversal of the call graph.",
+                INPUT_SCHEMA);
+
+        return new SyncToolSpecification(tool, (exchange, arguments) -> {
+            try {
+                String symbolInput = (String) arguments.get("symbol");
+                int depth = arguments.containsKey("depth")
+                        ? ((Number) arguments.get("depth")).intValue() : 3;
+
+                CallGraph callGraph = ctx.callGraph();
+
+                String resolved = resolveSymbol(callGraph, symbolInput);
+                if (resolved == null) {
+                    String error = ctx.objectMapper()
+                            .writeValueAsString(Map.of("error", "Symbol not found: " + symbolInput));
+                    return CallToolResult.builder()
+                            .addTextContent(error)
+                            .isError(Boolean.TRUE)
+                            .build();
+                }
+
+                List<String> callers = callGraph.blastRadiusCallers(resolved, depth);
+                String json = ctx.objectMapper().writeValueAsString(
+                        Map.of("target", resolved, "depth", depth, "callers", callers));
+                return CallToolResult.builder()
+                        .addTextContent(json)
+                        .build();
+            } catch (Exception e) {
+                return CallToolResult.builder()
+                        .addTextContent("{\"error\":\"" + e.getMessage() + "\"}")
+                        .isError(Boolean.TRUE)
+                        .build();
+            }
+        });
+    }
+
+    private String resolveSymbol(CallGraph callGraph, String input) {
+        SymbolNode exact = callGraph.getNode(input);
+        if (exact != null) {
+            return exact.getId();
+        }
+        for (SymbolNode node : callGraph.getNodes()) {
+            if (node.getId().contains(input)) {
+                return node.getId();
+            }
+        }
+        return null;
+    }
+}

--- a/graphus-cli/src/main/java/io/graphus/cli/mcp/tools/CalleesTool.java
+++ b/graphus-cli/src/main/java/io/graphus/cli/mcp/tools/CalleesTool.java
@@ -1,0 +1,71 @@
+package io.graphus.cli.mcp.tools;
+
+import io.graphus.cli.mcp.GraphusMcpContext;
+import io.graphus.model.CallGraph;
+import io.graphus.model.SymbolNode;
+import io.modelcontextprotocol.server.McpServerFeatures.SyncToolSpecification;
+import io.modelcontextprotocol.spec.McpSchema.CallToolResult;
+import io.modelcontextprotocol.spec.McpSchema.Tool;
+import java.util.Map;
+import java.util.Set;
+
+public final class CalleesTool {
+
+    private static final String INPUT_SCHEMA =
+            "{\"type\":\"object\",\"properties\":{\"symbol\":{\"type\":\"string\",\"description\":\"Fully qualified symbol ID or substring\"}},\"required\":[\"symbol\"]}";
+
+    private final GraphusMcpContext ctx;
+
+    public CalleesTool(GraphusMcpContext ctx) {
+        this.ctx = ctx;
+    }
+
+    public SyncToolSpecification spec() {
+        Tool tool = new Tool(
+                "graphus_callees",
+                "Find the direct (depth-1) callees of a symbol using the call graph.",
+                INPUT_SCHEMA);
+
+        return new SyncToolSpecification(tool, (exchange, arguments) -> {
+            try {
+                String symbolInput = (String) arguments.get("symbol");
+                CallGraph callGraph = ctx.callGraph();
+
+                String resolved = resolveSymbol(callGraph, symbolInput);
+                if (resolved == null) {
+                    String error = ctx.objectMapper()
+                            .writeValueAsString(Map.of("error", "Symbol not found: " + symbolInput));
+                    return CallToolResult.builder()
+                            .addTextContent(error)
+                            .isError(Boolean.TRUE)
+                            .build();
+                }
+
+                Set<String> callees = callGraph.outgoingNeighbors(resolved);
+                String json = ctx.objectMapper().writeValueAsString(
+                        Map.of("symbol", resolved, "callees", callees));
+                return CallToolResult.builder()
+                        .addTextContent(json)
+                        .build();
+            } catch (Exception e) {
+                return CallToolResult.builder()
+                        .addTextContent("{\"error\":\"" + e.getMessage() + "\"}")
+                        .isError(Boolean.TRUE)
+                        .build();
+            }
+        });
+    }
+
+    private String resolveSymbol(CallGraph callGraph, String input) {
+        SymbolNode exact = callGraph.getNode(input);
+        if (exact != null) {
+            return exact.getId();
+        }
+        for (SymbolNode node : callGraph.getNodes()) {
+            if (node.getId().contains(input)) {
+                return node.getId();
+            }
+        }
+        return null;
+    }
+}

--- a/graphus-cli/src/main/java/io/graphus/cli/mcp/tools/CallersTool.java
+++ b/graphus-cli/src/main/java/io/graphus/cli/mcp/tools/CallersTool.java
@@ -1,0 +1,71 @@
+package io.graphus.cli.mcp.tools;
+
+import io.graphus.cli.mcp.GraphusMcpContext;
+import io.graphus.model.CallGraph;
+import io.graphus.model.SymbolNode;
+import io.modelcontextprotocol.server.McpServerFeatures.SyncToolSpecification;
+import io.modelcontextprotocol.spec.McpSchema.CallToolResult;
+import io.modelcontextprotocol.spec.McpSchema.Tool;
+import java.util.Map;
+import java.util.Set;
+
+public final class CallersTool {
+
+    private static final String INPUT_SCHEMA =
+            "{\"type\":\"object\",\"properties\":{\"symbol\":{\"type\":\"string\",\"description\":\"Fully qualified symbol ID or substring\"}},\"required\":[\"symbol\"]}";
+
+    private final GraphusMcpContext ctx;
+
+    public CallersTool(GraphusMcpContext ctx) {
+        this.ctx = ctx;
+    }
+
+    public SyncToolSpecification spec() {
+        Tool tool = new Tool(
+                "graphus_callers",
+                "Find the direct (depth-1) callers of a symbol using the call graph.",
+                INPUT_SCHEMA);
+
+        return new SyncToolSpecification(tool, (exchange, arguments) -> {
+            try {
+                String symbolInput = (String) arguments.get("symbol");
+                CallGraph callGraph = ctx.callGraph();
+
+                String resolved = resolveSymbol(callGraph, symbolInput);
+                if (resolved == null) {
+                    String error = ctx.objectMapper()
+                            .writeValueAsString(Map.of("error", "Symbol not found: " + symbolInput));
+                    return CallToolResult.builder()
+                            .addTextContent(error)
+                            .isError(Boolean.TRUE)
+                            .build();
+                }
+
+                Set<String> callers = callGraph.incomingNeighbors(resolved);
+                String json = ctx.objectMapper().writeValueAsString(
+                        Map.of("symbol", resolved, "callers", callers));
+                return CallToolResult.builder()
+                        .addTextContent(json)
+                        .build();
+            } catch (Exception e) {
+                return CallToolResult.builder()
+                        .addTextContent("{\"error\":\"" + e.getMessage() + "\"}")
+                        .isError(Boolean.TRUE)
+                        .build();
+            }
+        });
+    }
+
+    private String resolveSymbol(CallGraph callGraph, String input) {
+        SymbolNode exact = callGraph.getNode(input);
+        if (exact != null) {
+            return exact.getId();
+        }
+        for (SymbolNode node : callGraph.getNodes()) {
+            if (node.getId().contains(input)) {
+                return node.getId();
+            }
+        }
+        return null;
+    }
+}

--- a/graphus-cli/src/main/java/io/graphus/cli/mcp/tools/HotspotsTool.java
+++ b/graphus-cli/src/main/java/io/graphus/cli/mcp/tools/HotspotsTool.java
@@ -1,0 +1,122 @@
+package io.graphus.cli.mcp.tools;
+
+import io.graphus.cli.git.ChurnAnalyzer;
+import io.graphus.cli.git.GitLogParser;
+import io.graphus.cli.mcp.GraphusMcpContext;
+import io.graphus.model.CallEdge;
+import io.graphus.model.CallGraph;
+import io.graphus.model.SymbolNode;
+import io.modelcontextprotocol.server.McpServerFeatures.SyncToolSpecification;
+import io.modelcontextprotocol.spec.McpSchema.CallToolResult;
+import io.modelcontextprotocol.spec.McpSchema.Tool;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+public final class HotspotsTool {
+
+    private static final String INPUT_SCHEMA =
+            "{\"type\":\"object\",\"properties\":{\"since_days\":{\"type\":\"integer\",\"description\":\"Days of git history (default 365, 0=all)\"},\"top\":{\"type\":\"integer\",\"description\":\"Max entries (default 20)\"}}}";
+
+    private final GraphusMcpContext ctx;
+
+    public HotspotsTool(GraphusMcpContext ctx) {
+        this.ctx = ctx;
+    }
+
+    public SyncToolSpecification spec() {
+        Tool tool = new Tool(
+                "graphus_hotspots",
+                "Rank files by churn × coupling (git commit frequency × distinct callers). High scores = riskiest files to touch.",
+                INPUT_SCHEMA);
+
+        return new SyncToolSpecification(tool, (exchange, arguments) -> {
+            try {
+                int sinceDays = arguments.containsKey("since_days")
+                        ? ((Number) arguments.get("since_days")).intValue()
+                        : 365;
+                int top = arguments.containsKey("top")
+                        ? ((Number) arguments.get("top")).intValue()
+                        : 20;
+
+                Map<String, Integer> churn = computeChurn(sinceDays);
+                Map<String, Integer> coupling = computeCoupling(ctx.callGraph());
+
+                Set<String> allFiles = new HashSet<>();
+                allFiles.addAll(churn.keySet());
+                allFiles.addAll(coupling.keySet());
+
+                List<Map<String, Object>> entries = new ArrayList<>();
+                for (String file : allFiles) {
+                    int c = churn.getOrDefault(file, 0);
+                    int k = coupling.getOrDefault(file, 0);
+                    int score = c * k;
+                    if (score == 0) {
+                        continue;
+                    }
+                    Map<String, Object> entry = new LinkedHashMap<>();
+                    entry.put("file", file);
+                    entry.put("churn", c);
+                    entry.put("coupling", k);
+                    entry.put("score", score);
+                    entries.add(entry);
+                }
+
+                entries.sort(Comparator.comparingInt((Map<String, Object> e) ->
+                        (Integer) e.get("score")).reversed());
+
+                List<Map<String, Object>> result = entries.size() <= top
+                        ? entries
+                        : entries.subList(0, top);
+
+                String json = ctx.objectMapper().writeValueAsString(result);
+                return CallToolResult.builder()
+                        .addTextContent(json)
+                        .build();
+            } catch (Exception e) {
+                return CallToolResult.builder()
+                        .addTextContent("[]")
+                        .build();
+            }
+        });
+    }
+
+    private Map<String, Integer> computeChurn(int sinceDays) throws Exception {
+        List<GitLogParser.CommitFiles> history =
+                GitLogParser.parseCommitFiles(ctx.repoRoot(), sinceDays);
+        return ChurnAnalyzer.analyze(history);
+    }
+
+    private static Map<String, Integer> computeCoupling(CallGraph callGraph) {
+        Map<String, Set<String>> callersByFile = new HashMap<>();
+
+        for (CallEdge edge : callGraph.getEdges()) {
+            SymbolNode toNode = callGraph.getNode(edge.toId());
+            SymbolNode fromNode = callGraph.getNode(edge.fromId());
+            if (toNode == null || fromNode == null) {
+                continue;
+            }
+            String targetFile = toNode.getFilePath();
+            String callerFile = fromNode.getFilePath();
+            if (isBlank(targetFile) || isBlank(callerFile) || targetFile.equals(callerFile)) {
+                continue;
+            }
+            callersByFile.computeIfAbsent(targetFile, k -> new HashSet<>()).add(callerFile);
+        }
+
+        Map<String, Integer> coupling = new HashMap<>();
+        for (Map.Entry<String, Set<String>> entry : callersByFile.entrySet()) {
+            coupling.put(entry.getKey(), entry.getValue().size());
+        }
+        return coupling;
+    }
+
+    private static boolean isBlank(String s) {
+        return s == null || s.isBlank();
+    }
+}

--- a/graphus-cli/src/main/java/io/graphus/cli/mcp/tools/ModuleDepsTool.java
+++ b/graphus-cli/src/main/java/io/graphus/cli/mcp/tools/ModuleDepsTool.java
@@ -1,0 +1,69 @@
+package io.graphus.cli.mcp.tools;
+
+import io.graphus.cli.mcp.GraphusMcpContext;
+import io.graphus.model.CallGraph;
+import io.graphus.model.ModuleNode;
+import io.graphus.model.SymbolNode;
+import io.modelcontextprotocol.server.McpServerFeatures.SyncToolSpecification;
+import io.modelcontextprotocol.spec.McpSchema.CallToolResult;
+import io.modelcontextprotocol.spec.McpSchema.Tool;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+public final class ModuleDepsTool {
+
+    private static final String INPUT_SCHEMA =
+            "{\"type\":\"object\",\"properties\":{\"module\":{\"type\":\"string\",\"description\":\"Optional module name to scope results\"}}}";
+
+    private final GraphusMcpContext ctx;
+
+    public ModuleDepsTool(GraphusMcpContext ctx) {
+        this.ctx = ctx;
+    }
+
+    public SyncToolSpecification spec() {
+        Tool tool = new Tool(
+                "graphus_module_deps",
+                "Return the module dependency graph. Optional 'module' filter scopes output to a single module's dependencies.",
+                INPUT_SCHEMA);
+
+        return new SyncToolSpecification(tool, (exchange, arguments) -> {
+            try {
+                String moduleFilter = (String) arguments.get("module");
+                CallGraph callGraph = ctx.callGraph();
+
+                Set<String> allModuleIds = callGraph.getNodes().stream()
+                        .filter(n -> n instanceof ModuleNode)
+                        .map(SymbolNode::getId)
+                        .collect(Collectors.toSet());
+
+                List<Map<String, Object>> results = new ArrayList<>();
+                for (SymbolNode node : callGraph.getNodes()) {
+                    if (!(node instanceof ModuleNode)) {
+                        continue;
+                    }
+                    if (moduleFilter != null && !node.getId().contains(moduleFilter)) {
+                        continue;
+                    }
+                    Set<String> deps = callGraph.outgoingNeighbors(node.getId()).stream()
+                            .filter(allModuleIds::contains)
+                            .collect(Collectors.toSet());
+                    results.add(Map.of("module", node.getId(), "depends_on", deps));
+                }
+
+                String json = ctx.objectMapper().writeValueAsString(results);
+                return CallToolResult.builder()
+                        .addTextContent(json)
+                        .build();
+            } catch (Exception e) {
+                return CallToolResult.builder()
+                        .addTextContent("{\"error\":\"" + e.getMessage() + "\"}")
+                        .isError(Boolean.TRUE)
+                        .build();
+            }
+        });
+    }
+}

--- a/graphus-cli/src/main/java/io/graphus/cli/mcp/tools/OwnershipTool.java
+++ b/graphus-cli/src/main/java/io/graphus/cli/mcp/tools/OwnershipTool.java
@@ -1,0 +1,66 @@
+package io.graphus.cli.mcp.tools;
+
+import io.graphus.cli.mcp.GraphusMcpContext;
+import io.modelcontextprotocol.server.McpServerFeatures.SyncToolSpecification;
+import io.modelcontextprotocol.spec.McpSchema.CallToolResult;
+import io.modelcontextprotocol.spec.McpSchema.Tool;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Map;
+
+public final class OwnershipTool {
+
+    private static final String INPUT_SCHEMA =
+            "{\"type\":\"object\",\"properties\":{\"path\":{\"type\":\"string\",\"description\":\"Optional file path substring to filter results\"}}}";
+
+    private final GraphusMcpContext ctx;
+
+    public OwnershipTool(GraphusMcpContext ctx) {
+        this.ctx = ctx;
+    }
+
+    public SyncToolSpecification spec() {
+        Tool tool = new Tool(
+                "graphus_ownership",
+                "Return file ownership (primary author per file) from git-analyze output. Requires 'graphus git-analyze' to have been run first.",
+                INPUT_SCHEMA);
+
+        return new SyncToolSpecification(tool, (exchange, arguments) -> {
+            try {
+                Path ownershipFile = ctx.stateDir().resolve("ownership.json");
+                if (!Files.exists(ownershipFile)) {
+                    String error = ctx.objectMapper()
+                            .writeValueAsString(Map.of("error",
+                                    "ownership.json not found. Run 'graphus git-analyze' first."));
+                    return CallToolResult.builder()
+                            .addTextContent(error)
+                            .isError(Boolean.TRUE)
+                            .build();
+                }
+
+                @SuppressWarnings("unchecked")
+                Map<String, String> ownership = ctx.objectMapper()
+                        .readValue(ownershipFile.toFile(), Map.class);
+
+                String pathFilter = (String) arguments.get("path");
+                if (pathFilter != null && !pathFilter.isBlank()) {
+                    ownership = ownership.entrySet().stream()
+                            .filter(e -> e.getKey().contains(pathFilter))
+                            .collect(java.util.stream.Collectors.toMap(
+                                    Map.Entry::getKey,
+                                    Map.Entry::getValue));
+                }
+
+                String json = ctx.objectMapper().writeValueAsString(ownership);
+                return CallToolResult.builder()
+                        .addTextContent(json)
+                        .build();
+            } catch (Exception e) {
+                return CallToolResult.builder()
+                        .addTextContent("{\"error\":\"" + e.getMessage() + "\"}")
+                        .isError(Boolean.TRUE)
+                        .build();
+            }
+        });
+    }
+}

--- a/graphus-cli/src/main/java/io/graphus/cli/mcp/tools/SearchTool.java
+++ b/graphus-cli/src/main/java/io/graphus/cli/mcp/tools/SearchTool.java
@@ -1,0 +1,64 @@
+package io.graphus.cli.mcp.tools;
+
+import io.graphus.cli.mcp.GraphusMcpContext;
+import io.graphus.indexer.GraphSearchHit;
+import io.modelcontextprotocol.server.McpServerFeatures.SyncToolSpecification;
+import io.modelcontextprotocol.spec.McpSchema.CallToolResult;
+import io.modelcontextprotocol.spec.McpSchema.TextContent;
+import io.modelcontextprotocol.spec.McpSchema.Tool;
+import java.util.List;
+import java.util.Map;
+
+public final class SearchTool {
+
+    private static final String INPUT_SCHEMA = """
+            {
+              "type": "object",
+              "properties": {
+                "query": { "type": "string", "description": "Natural language search query" },
+                "top_k": { "type": "integer", "description": "Maximum results to return (default 10)" },
+                "module": { "type": "string", "description": "Optional module name filter" }
+              },
+              "required": ["query"]
+            }
+            """;
+
+    private final GraphusMcpContext ctx;
+
+    public SearchTool(GraphusMcpContext ctx) {
+        this.ctx = ctx;
+    }
+
+    public SyncToolSpecification spec() {
+        Tool tool = new Tool(
+                "graphus_search",
+                "Search indexed code symbols by natural language query. Returns matching symbols with score, text, and metadata.",
+                INPUT_SCHEMA);
+
+        return new SyncToolSpecification(tool, (exchange, arguments) -> {
+            try {
+                String query = (String) arguments.get("query");
+                int topK = arguments.containsKey("top_k")
+                        ? ((Number) arguments.get("top_k")).intValue() : 10;
+                String module = (String) arguments.get("module");
+
+                List<GraphSearchHit> hits = ctx.graphIndexer().query(query, module, topK);
+                List<Map<String, Object>> payload = hits.stream()
+                        .map(h -> Map.<String, Object>of(
+                                "score", h.score(),
+                                "text", h.text(),
+                                "metadata", h.metadata()))
+                        .toList();
+                String json = ctx.objectMapper().writeValueAsString(payload);
+                return CallToolResult.builder()
+                        .addTextContent(json)
+                        .build();
+            } catch (Exception e) {
+                return CallToolResult.builder()
+                        .addTextContent("{\"error\":\"" + e.getMessage() + "\"}")
+                        .isError(Boolean.TRUE)
+                        .build();
+            }
+        });
+    }
+}

--- a/graphus-cli/src/test/java/io/graphus/cli/mcp/tools/BlastRadiusToolTest.java
+++ b/graphus-cli/src/test/java/io/graphus/cli/mcp/tools/BlastRadiusToolTest.java
@@ -1,0 +1,93 @@
+package io.graphus.cli.mcp.tools;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.graphus.cli.mcp.GraphusMcpContext;
+import io.graphus.model.CallGraph;
+import io.graphus.model.MethodNode;
+import io.modelcontextprotocol.server.McpServerFeatures.SyncToolSpecification;
+import io.modelcontextprotocol.spec.McpSchema.CallToolResult;
+import io.modelcontextprotocol.spec.McpSchema.TextContent;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class BlastRadiusToolTest {
+
+    @Test
+    void spec_hasCorrectToolName() {
+        GraphusMcpContext ctx = mock(GraphusMcpContext.class);
+        when(ctx.objectMapper()).thenReturn(new ObjectMapper());
+        BlastRadiusTool tool = new BlastRadiusTool(ctx);
+        SyncToolSpecification spec = tool.spec();
+        assertEquals("graphus_blast_radius", spec.tool().name());
+    }
+
+    @Test
+    void callHandler_returnsCallerInJson_whenSymbolFound() throws Exception {
+        CallGraph callGraph = new CallGraph();
+        MethodNode target = new MethodNode(
+                "com.example.Service.process()",
+                "com.example.Service",
+                "process",
+                "process()",
+                "void",
+                List.of(),
+                List.of(),
+                List.of(),
+                "Service.java",
+                10,
+                null
+        );
+        MethodNode caller = new MethodNode(
+                "com.example.Controller.handle()",
+                "com.example.Controller",
+                "handle",
+                "handle()",
+                "void",
+                List.of(),
+                List.of(),
+                List.of(),
+                "Controller.java",
+                5,
+                null
+        );
+        callGraph.addNode(target);
+        callGraph.addNode(caller);
+        callGraph.addEdge("com.example.Controller.handle()", "com.example.Service.process()");
+
+        GraphusMcpContext ctx = mock(GraphusMcpContext.class);
+        when(ctx.objectMapper()).thenReturn(new ObjectMapper());
+        when(ctx.callGraph()).thenReturn(callGraph);
+
+        BlastRadiusTool tool = new BlastRadiusTool(ctx);
+        CallToolResult result = tool.spec().call().apply(null,
+                Map.of("symbol", "com.example.Service.process()"));
+
+        assertFalse(Boolean.TRUE.equals(result.isError()));
+        String json = ((TextContent) result.content().get(0)).text();
+        assertTrue(json.contains("com.example.Controller.handle()"));
+        assertTrue(json.contains("com.example.Service.process()"));
+    }
+
+    @Test
+    void callHandler_returnsError_whenSymbolNotFound() {
+        CallGraph callGraph = new CallGraph();
+
+        GraphusMcpContext ctx = mock(GraphusMcpContext.class);
+        when(ctx.objectMapper()).thenReturn(new ObjectMapper());
+        when(ctx.callGraph()).thenReturn(callGraph);
+
+        BlastRadiusTool tool = new BlastRadiusTool(ctx);
+        CallToolResult result = tool.spec().call().apply(null,
+                Map.of("symbol", "com.example.Unknown.missing()"));
+
+        assertTrue(Boolean.TRUE.equals(result.isError()));
+        String json = ((TextContent) result.content().get(0)).text();
+        assertTrue(json.contains("Symbol not found"));
+    }
+}

--- a/graphus-cli/src/test/java/io/graphus/cli/mcp/tools/CalleesToolTest.java
+++ b/graphus-cli/src/test/java/io/graphus/cli/mcp/tools/CalleesToolTest.java
@@ -1,0 +1,140 @@
+package io.graphus.cli.mcp.tools;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.graphus.cli.mcp.GraphusMcpContext;
+import io.graphus.model.CallGraph;
+import io.graphus.model.MethodNode;
+import io.modelcontextprotocol.server.McpServerFeatures.SyncToolSpecification;
+import io.modelcontextprotocol.spec.McpSchema.CallToolResult;
+import io.modelcontextprotocol.spec.McpSchema.TextContent;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class CalleesToolTest {
+
+    @Test
+    void spec_hasCorrectToolName() {
+        GraphusMcpContext ctx = mock(GraphusMcpContext.class);
+        when(ctx.objectMapper()).thenReturn(new ObjectMapper());
+        CalleesTool tool = new CalleesTool(ctx);
+        SyncToolSpecification spec = tool.spec();
+        assertEquals("graphus_callees", spec.tool().name());
+    }
+
+    @Test
+    void callHandler_returnsDirectCallees_whenSymbolFound() throws Exception {
+        CallGraph callGraph = new CallGraph();
+        MethodNode caller = new MethodNode(
+                "com.example.Controller.handle()",
+                "com.example.Controller",
+                "handle",
+                "handle()",
+                "void",
+                List.of(),
+                List.of(),
+                List.of(),
+                "Controller.java",
+                5,
+                null
+        );
+        MethodNode callee = new MethodNode(
+                "com.example.Service.process()",
+                "com.example.Service",
+                "process",
+                "process()",
+                "void",
+                List.of(),
+                List.of(),
+                List.of(),
+                "Service.java",
+                10,
+                null
+        );
+        callGraph.addNode(caller);
+        callGraph.addNode(callee);
+        callGraph.addEdge("com.example.Controller.handle()", "com.example.Service.process()");
+
+        GraphusMcpContext ctx = mock(GraphusMcpContext.class);
+        when(ctx.objectMapper()).thenReturn(new ObjectMapper());
+        when(ctx.callGraph()).thenReturn(callGraph);
+
+        CalleesTool tool = new CalleesTool(ctx);
+        CallToolResult result = tool.spec().call().apply(null,
+                Map.of("symbol", "com.example.Controller.handle()"));
+
+        assertFalse(Boolean.TRUE.equals(result.isError()));
+        String json = ((TextContent) result.content().get(0)).text();
+        assertTrue(json.contains("com.example.Controller.handle()"));
+        assertTrue(json.contains("com.example.Service.process()"));
+    }
+
+    @Test
+    void callHandler_resolvesBySubstring() throws Exception {
+        CallGraph callGraph = new CallGraph();
+        MethodNode caller = new MethodNode(
+                "com.example.Controller.handle()",
+                "com.example.Controller",
+                "handle",
+                "handle()",
+                "void",
+                List.of(),
+                List.of(),
+                List.of(),
+                "Controller.java",
+                5,
+                null
+        );
+        MethodNode callee = new MethodNode(
+                "com.example.Service.process()",
+                "com.example.Service",
+                "process",
+                "process()",
+                "void",
+                List.of(),
+                List.of(),
+                List.of(),
+                "Service.java",
+                10,
+                null
+        );
+        callGraph.addNode(caller);
+        callGraph.addNode(callee);
+        callGraph.addEdge("com.example.Controller.handle()", "com.example.Service.process()");
+
+        GraphusMcpContext ctx = mock(GraphusMcpContext.class);
+        when(ctx.objectMapper()).thenReturn(new ObjectMapper());
+        when(ctx.callGraph()).thenReturn(callGraph);
+
+        CalleesTool tool = new CalleesTool(ctx);
+        CallToolResult result = tool.spec().call().apply(null,
+                Map.of("symbol", "Controller.handle"));
+
+        assertFalse(Boolean.TRUE.equals(result.isError()));
+        String json = ((TextContent) result.content().get(0)).text();
+        assertTrue(json.contains("com.example.Controller.handle()"));
+        assertTrue(json.contains("com.example.Service.process()"));
+    }
+
+    @Test
+    void callHandler_returnsError_whenSymbolNotFound() {
+        CallGraph callGraph = new CallGraph();
+
+        GraphusMcpContext ctx = mock(GraphusMcpContext.class);
+        when(ctx.objectMapper()).thenReturn(new ObjectMapper());
+        when(ctx.callGraph()).thenReturn(callGraph);
+
+        CalleesTool tool = new CalleesTool(ctx);
+        CallToolResult result = tool.spec().call().apply(null,
+                Map.of("symbol", "com.example.Unknown.missing()"));
+
+        assertTrue(Boolean.TRUE.equals(result.isError()));
+        String json = ((TextContent) result.content().get(0)).text();
+        assertTrue(json.contains("Symbol not found"));
+    }
+}

--- a/graphus-cli/src/test/java/io/graphus/cli/mcp/tools/CallersToolTest.java
+++ b/graphus-cli/src/test/java/io/graphus/cli/mcp/tools/CallersToolTest.java
@@ -1,0 +1,140 @@
+package io.graphus.cli.mcp.tools;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.graphus.cli.mcp.GraphusMcpContext;
+import io.graphus.model.CallGraph;
+import io.graphus.model.MethodNode;
+import io.modelcontextprotocol.server.McpServerFeatures.SyncToolSpecification;
+import io.modelcontextprotocol.spec.McpSchema.CallToolResult;
+import io.modelcontextprotocol.spec.McpSchema.TextContent;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class CallersToolTest {
+
+    @Test
+    void spec_hasCorrectToolName() {
+        GraphusMcpContext ctx = mock(GraphusMcpContext.class);
+        when(ctx.objectMapper()).thenReturn(new ObjectMapper());
+        CallersTool tool = new CallersTool(ctx);
+        SyncToolSpecification spec = tool.spec();
+        assertEquals("graphus_callers", spec.tool().name());
+    }
+
+    @Test
+    void callHandler_returnsDirectCallers_whenSymbolFound() throws Exception {
+        CallGraph callGraph = new CallGraph();
+        MethodNode target = new MethodNode(
+                "com.example.Service.process()",
+                "com.example.Service",
+                "process",
+                "process()",
+                "void",
+                List.of(),
+                List.of(),
+                List.of(),
+                "Service.java",
+                10,
+                null
+        );
+        MethodNode caller = new MethodNode(
+                "com.example.Controller.handle()",
+                "com.example.Controller",
+                "handle",
+                "handle()",
+                "void",
+                List.of(),
+                List.of(),
+                List.of(),
+                "Controller.java",
+                5,
+                null
+        );
+        callGraph.addNode(target);
+        callGraph.addNode(caller);
+        callGraph.addEdge("com.example.Controller.handle()", "com.example.Service.process()");
+
+        GraphusMcpContext ctx = mock(GraphusMcpContext.class);
+        when(ctx.objectMapper()).thenReturn(new ObjectMapper());
+        when(ctx.callGraph()).thenReturn(callGraph);
+
+        CallersTool tool = new CallersTool(ctx);
+        CallToolResult result = tool.spec().call().apply(null,
+                Map.of("symbol", "com.example.Service.process()"));
+
+        assertFalse(Boolean.TRUE.equals(result.isError()));
+        String json = ((TextContent) result.content().get(0)).text();
+        assertTrue(json.contains("com.example.Service.process()"));
+        assertTrue(json.contains("com.example.Controller.handle()"));
+    }
+
+    @Test
+    void callHandler_resolvesBySubstring() throws Exception {
+        CallGraph callGraph = new CallGraph();
+        MethodNode target = new MethodNode(
+                "com.example.Service.process()",
+                "com.example.Service",
+                "process",
+                "process()",
+                "void",
+                List.of(),
+                List.of(),
+                List.of(),
+                "Service.java",
+                10,
+                null
+        );
+        MethodNode caller = new MethodNode(
+                "com.example.Controller.handle()",
+                "com.example.Controller",
+                "handle",
+                "handle()",
+                "void",
+                List.of(),
+                List.of(),
+                List.of(),
+                "Controller.java",
+                5,
+                null
+        );
+        callGraph.addNode(target);
+        callGraph.addNode(caller);
+        callGraph.addEdge("com.example.Controller.handle()", "com.example.Service.process()");
+
+        GraphusMcpContext ctx = mock(GraphusMcpContext.class);
+        when(ctx.objectMapper()).thenReturn(new ObjectMapper());
+        when(ctx.callGraph()).thenReturn(callGraph);
+
+        CallersTool tool = new CallersTool(ctx);
+        CallToolResult result = tool.spec().call().apply(null,
+                Map.of("symbol", "Service.process"));
+
+        assertFalse(Boolean.TRUE.equals(result.isError()));
+        String json = ((TextContent) result.content().get(0)).text();
+        assertTrue(json.contains("com.example.Service.process()"));
+        assertTrue(json.contains("com.example.Controller.handle()"));
+    }
+
+    @Test
+    void callHandler_returnsError_whenSymbolNotFound() {
+        CallGraph callGraph = new CallGraph();
+
+        GraphusMcpContext ctx = mock(GraphusMcpContext.class);
+        when(ctx.objectMapper()).thenReturn(new ObjectMapper());
+        when(ctx.callGraph()).thenReturn(callGraph);
+
+        CallersTool tool = new CallersTool(ctx);
+        CallToolResult result = tool.spec().call().apply(null,
+                Map.of("symbol", "com.example.Unknown.missing()"));
+
+        assertTrue(Boolean.TRUE.equals(result.isError()));
+        String json = ((TextContent) result.content().get(0)).text();
+        assertTrue(json.contains("Symbol not found"));
+    }
+}

--- a/graphus-cli/src/test/java/io/graphus/cli/mcp/tools/HotspotsToolTest.java
+++ b/graphus-cli/src/test/java/io/graphus/cli/mcp/tools/HotspotsToolTest.java
@@ -1,0 +1,116 @@
+package io.graphus.cli.mcp.tools;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.graphus.cli.mcp.GraphusMcpContext;
+import io.graphus.model.CallGraph;
+import io.graphus.model.MethodNode;
+import io.modelcontextprotocol.server.McpServerFeatures.SyncToolSpecification;
+import io.modelcontextprotocol.spec.McpSchema.CallToolResult;
+import io.modelcontextprotocol.spec.McpSchema.TextContent;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class HotspotsToolTest {
+
+    @Test
+    void spec_hasCorrectToolName() {
+        GraphusMcpContext ctx = mock(GraphusMcpContext.class);
+        when(ctx.objectMapper()).thenReturn(new ObjectMapper());
+        when(ctx.callGraph()).thenReturn(new CallGraph());
+        when(ctx.repoRoot()).thenReturn(Path.of("/tmp/no-such-repo-" + System.nanoTime()));
+
+        HotspotsTool tool = new HotspotsTool(ctx);
+        SyncToolSpecification spec = tool.spec();
+        assertEquals("graphus_hotspots", spec.tool().name());
+    }
+
+    @Test
+    void callHandler_returnsEmptyArray_whenRepoRootHasNoGitHistory(@TempDir Path tempDir) {
+        GraphusMcpContext ctx = mock(GraphusMcpContext.class);
+        when(ctx.objectMapper()).thenReturn(new ObjectMapper());
+        when(ctx.callGraph()).thenReturn(new CallGraph());
+        when(ctx.repoRoot()).thenReturn(tempDir);
+
+        HotspotsTool tool = new HotspotsTool(ctx);
+        CallToolResult result = tool.spec().call().apply(null, Map.of());
+
+        assertFalse(Boolean.TRUE.equals(result.isError()));
+        String json = ((TextContent) result.content().get(0)).text();
+        assertTrue(json.startsWith("["), "Expected JSON array but got: " + json);
+    }
+
+    @Test
+    void callHandler_returnsEmptyArray_whenNonExistentRepoRoot() {
+        Path noSuchRepo = Path.of("/tmp/no-such-repo-" + System.nanoTime());
+
+        GraphusMcpContext ctx = mock(GraphusMcpContext.class);
+        when(ctx.objectMapper()).thenReturn(new ObjectMapper());
+        when(ctx.callGraph()).thenReturn(new CallGraph());
+        when(ctx.repoRoot()).thenReturn(noSuchRepo);
+
+        HotspotsTool tool = new HotspotsTool(ctx);
+        CallToolResult result = tool.spec().call().apply(null, Map.of("since_days", 30, "top", 10));
+
+        assertFalse(Boolean.TRUE.equals(result.isError()));
+        String json = ((TextContent) result.content().get(0)).text();
+        assertTrue(json.startsWith("["), "Expected JSON array but got: " + json);
+        assertEquals("[]", json.trim());
+    }
+
+    @Test
+    void callHandler_computesScores_withCallGraphCoupling(@TempDir Path tempDir) {
+        CallGraph callGraph = new CallGraph();
+
+        MethodNode targetNode = new MethodNode(
+                "com.example.Service.process()",
+                "com.example.Service",
+                "process",
+                "process()",
+                "void",
+                List.of(),
+                List.of(),
+                List.of(),
+                "src/main/java/com/example/Service.java",
+                10,
+                null
+        );
+        MethodNode callerNode = new MethodNode(
+                "com.example.Controller.handle()",
+                "com.example.Controller",
+                "handle",
+                "handle()",
+                "void",
+                List.of(),
+                List.of(),
+                List.of(),
+                "src/main/java/com/example/Controller.java",
+                5,
+                null
+        );
+        callGraph.addNode(targetNode);
+        callGraph.addNode(callerNode);
+        callGraph.addEdge("com.example.Controller.handle()", "com.example.Service.process()");
+
+        GraphusMcpContext ctx = mock(GraphusMcpContext.class);
+        when(ctx.objectMapper()).thenReturn(new ObjectMapper());
+        when(ctx.callGraph()).thenReturn(callGraph);
+        when(ctx.repoRoot()).thenReturn(tempDir);
+
+        HotspotsTool tool = new HotspotsTool(ctx);
+        // since_days=0 means all history; tempDir has no git, so churn=0 but coupling exists
+        CallToolResult result = tool.spec().call().apply(null, Map.of("since_days", 0, "top", 20));
+
+        assertFalse(Boolean.TRUE.equals(result.isError()));
+        String json = ((TextContent) result.content().get(0)).text();
+        // With no git history churn=0, coupling=1 → score=0, so items with score=0 are skipped
+        assertTrue(json.startsWith("["), "Expected JSON array but got: " + json);
+    }
+}

--- a/graphus-cli/src/test/java/io/graphus/cli/mcp/tools/ModuleDepsToolTest.java
+++ b/graphus-cli/src/test/java/io/graphus/cli/mcp/tools/ModuleDepsToolTest.java
@@ -1,0 +1,73 @@
+package io.graphus.cli.mcp.tools;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.graphus.cli.mcp.GraphusMcpContext;
+import io.graphus.model.CallGraph;
+import io.graphus.model.ModuleNode;
+import io.modelcontextprotocol.server.McpServerFeatures.SyncToolSpecification;
+import io.modelcontextprotocol.spec.McpSchema.CallToolResult;
+import io.modelcontextprotocol.spec.McpSchema.TextContent;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class ModuleDepsToolTest {
+
+    @Test
+    void spec_hasCorrectToolName() {
+        GraphusMcpContext ctx = mock(GraphusMcpContext.class);
+        when(ctx.objectMapper()).thenReturn(new ObjectMapper());
+        ModuleDepsTool tool = new ModuleDepsTool(ctx);
+        SyncToolSpecification spec = tool.spec();
+        assertEquals("graphus_module_deps", spec.tool().name());
+    }
+
+    @Test
+    void callHandler_returnsAllModules_whenNoFilter() throws Exception {
+        CallGraph callGraph = new CallGraph();
+        ModuleNode moduleA = new ModuleNode("graphus-core");
+        ModuleNode moduleB = new ModuleNode("graphus-cli");
+        callGraph.addNode(moduleA);
+        callGraph.addNode(moduleB);
+        callGraph.addEdge(ModuleNode.idFor("graphus-cli"), ModuleNode.idFor("graphus-core"));
+
+        GraphusMcpContext ctx = mock(GraphusMcpContext.class);
+        when(ctx.objectMapper()).thenReturn(new ObjectMapper());
+        when(ctx.callGraph()).thenReturn(callGraph);
+
+        ModuleDepsTool tool = new ModuleDepsTool(ctx);
+        CallToolResult result = tool.spec().call().apply(null, Map.of());
+
+        assertFalse(Boolean.TRUE.equals(result.isError()));
+        String json = ((TextContent) result.content().get(0)).text();
+        assertTrue(json.contains("graphus-core"), "Expected graphus-core in output");
+        assertTrue(json.contains("graphus-cli"), "Expected graphus-cli in output");
+    }
+
+    @Test
+    void callHandler_filtersByModule_whenFilterProvided() throws Exception {
+        CallGraph callGraph = new CallGraph();
+        ModuleNode moduleA = new ModuleNode("graphus-core");
+        ModuleNode moduleB = new ModuleNode("graphus-cli");
+        callGraph.addNode(moduleA);
+        callGraph.addNode(moduleB);
+        callGraph.addEdge(ModuleNode.idFor("graphus-cli"), ModuleNode.idFor("graphus-core"));
+
+        GraphusMcpContext ctx = mock(GraphusMcpContext.class);
+        when(ctx.objectMapper()).thenReturn(new ObjectMapper());
+        when(ctx.callGraph()).thenReturn(callGraph);
+
+        ModuleDepsTool tool = new ModuleDepsTool(ctx);
+        CallToolResult result = tool.spec().call().apply(null, Map.of("module", "graphus-cli"));
+
+        assertFalse(Boolean.TRUE.equals(result.isError()));
+        String json = ((TextContent) result.content().get(0)).text();
+        assertTrue(json.contains("graphus-cli"), "Expected graphus-cli in filtered output");
+        assertFalse(json.contains("\"module:graphus-core\"") && !json.contains("depends_on"),
+                "graphus-core should appear only as a dependency, not as a top-level module entry");
+    }
+}

--- a/graphus-cli/src/test/java/io/graphus/cli/mcp/tools/OwnershipToolTest.java
+++ b/graphus-cli/src/test/java/io/graphus/cli/mcp/tools/OwnershipToolTest.java
@@ -1,0 +1,89 @@
+package io.graphus.cli.mcp.tools;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.graphus.cli.mcp.GraphusMcpContext;
+import io.modelcontextprotocol.server.McpServerFeatures.SyncToolSpecification;
+import io.modelcontextprotocol.spec.McpSchema.CallToolResult;
+import io.modelcontextprotocol.spec.McpSchema.TextContent;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class OwnershipToolTest {
+
+    @Test
+    void spec_hasCorrectToolName() {
+        GraphusMcpContext ctx = mock(GraphusMcpContext.class);
+        when(ctx.objectMapper()).thenReturn(new ObjectMapper());
+        when(ctx.stateDir()).thenReturn(Path.of("/tmp/no-such-state-" + System.nanoTime()));
+
+        OwnershipTool tool = new OwnershipTool(ctx);
+        SyncToolSpecification spec = tool.spec();
+        assertEquals("graphus_ownership", spec.tool().name());
+    }
+
+    @Test
+    void callHandler_returnsIsError_whenOwnershipJsonMissing(@TempDir Path tempDir) {
+        GraphusMcpContext ctx = mock(GraphusMcpContext.class);
+        when(ctx.objectMapper()).thenReturn(new ObjectMapper());
+        when(ctx.stateDir()).thenReturn(tempDir);
+
+        OwnershipTool tool = new OwnershipTool(ctx);
+        CallToolResult result = tool.spec().call().apply(null, Map.of());
+
+        assertTrue(Boolean.TRUE.equals(result.isError()));
+        String text = ((TextContent) result.content().get(0)).text();
+        assertTrue(text.contains("git-analyze"), "Expected error to mention git-analyze but got: " + text);
+    }
+
+    @Test
+    void callHandler_returnsOwnershipMap_whenOwnershipJsonExists(@TempDir Path tempDir) throws IOException {
+        ObjectMapper mapper = new ObjectMapper();
+        Map<String, String> ownership = Map.of(
+                "src/main/java/io/graphus/cli/GraphusCli.java", "alice@example.com",
+                "src/main/java/io/graphus/parser/JavaParser.java", "bob@example.com"
+        );
+        Files.writeString(tempDir.resolve("ownership.json"), mapper.writeValueAsString(ownership));
+
+        GraphusMcpContext ctx = mock(GraphusMcpContext.class);
+        when(ctx.objectMapper()).thenReturn(mapper);
+        when(ctx.stateDir()).thenReturn(tempDir);
+
+        OwnershipTool tool = new OwnershipTool(ctx);
+        CallToolResult result = tool.spec().call().apply(null, Map.of());
+
+        assertTrue(Boolean.FALSE.equals(result.isError()) || result.isError() == null);
+        String json = ((TextContent) result.content().get(0)).text();
+        assertTrue(json.contains("alice@example.com"));
+        assertTrue(json.contains("bob@example.com"));
+    }
+
+    @Test
+    void callHandler_filtersResults_whenPathArgumentProvided(@TempDir Path tempDir) throws IOException {
+        ObjectMapper mapper = new ObjectMapper();
+        Map<String, String> ownership = Map.of(
+                "src/main/java/io/graphus/cli/GraphusCli.java", "alice@example.com",
+                "src/main/java/io/graphus/parser/JavaParser.java", "bob@example.com"
+        );
+        Files.writeString(tempDir.resolve("ownership.json"), mapper.writeValueAsString(ownership));
+
+        GraphusMcpContext ctx = mock(GraphusMcpContext.class);
+        when(ctx.objectMapper()).thenReturn(mapper);
+        when(ctx.stateDir()).thenReturn(tempDir);
+
+        OwnershipTool tool = new OwnershipTool(ctx);
+        CallToolResult result = tool.spec().call().apply(null, Map.of("path", "cli"));
+
+        assertTrue(Boolean.FALSE.equals(result.isError()) || result.isError() == null);
+        String json = ((TextContent) result.content().get(0)).text();
+        assertTrue(json.contains("alice@example.com"), "Expected cli entry with alice");
+        assertTrue(!json.contains("bob@example.com"), "Expected parser entry to be filtered out");
+    }
+}

--- a/graphus-cli/src/test/java/io/graphus/cli/mcp/tools/SearchToolTest.java
+++ b/graphus-cli/src/test/java/io/graphus/cli/mcp/tools/SearchToolTest.java
@@ -1,0 +1,50 @@
+package io.graphus.cli.mcp.tools;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.graphus.cli.mcp.GraphusMcpContext;
+import io.graphus.indexer.GraphIndexer;
+import io.graphus.indexer.GraphSearchHit;
+import io.modelcontextprotocol.server.McpServerFeatures.SyncToolSpecification;
+import io.modelcontextprotocol.spec.McpSchema.CallToolRequest;
+import io.modelcontextprotocol.spec.McpSchema.CallToolResult;
+import io.modelcontextprotocol.spec.McpSchema.TextContent;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class SearchToolTest {
+
+    @Test
+    void spec_hasCorrectToolName() {
+        GraphusMcpContext ctx = mock(GraphusMcpContext.class);
+        when(ctx.objectMapper()).thenReturn(new ObjectMapper());
+        SearchTool tool = new SearchTool(ctx);
+        SyncToolSpecification spec = tool.spec();
+        assertEquals("graphus_search", spec.tool().name());
+    }
+
+    @Test
+    void callHandler_returnsHitsAsJson() throws Exception {
+        GraphusMcpContext ctx = mock(GraphusMcpContext.class);
+        GraphIndexer indexer = mock(GraphIndexer.class);
+        when(ctx.graphIndexer()).thenReturn(indexer);
+        when(ctx.objectMapper()).thenReturn(new ObjectMapper());
+        when(indexer.query("find payment service", null, 10))
+                .thenReturn(List.of(new GraphSearchHit(0.92, "PaymentService.process()", Map.of("kind", "METHOD"))));
+
+        SearchTool tool = new SearchTool(ctx);
+        CallToolRequest request = new CallToolRequest("graphus_search",
+                Map.of("query", "find payment service"));
+        CallToolResult result = tool.spec().call().apply(null, request.arguments());
+
+        assertFalse(Boolean.TRUE.equals(result.isError()));
+        String json = ((TextContent) result.content().get(0)).text();
+        assertTrue(json.contains("PaymentService.process()"));
+        assertTrue(json.contains("0.92"));
+    }
+}


### PR DESCRIPTION
## Summary

Implements a full MCP (Model Context Protocol) server for Graphus, exposing 7 code intelligence tools over STDIO so AI coding agents (Claude Code, Cursor, Copilot) can query the call graph and vector index directly from their tool context.

Related to #72

## Changes

- **Dependency**: adds `io.modelcontextprotocol.sdk:mcp:0.10.0` to `graphus-cli/build.gradle.kts`
- **Startup context**: `GraphusMcpContext` loads `CallGraph` + `GraphIndexer` once at startup; all diagnostic output goes to stderr to keep STDIO clean
- **7 MCP tools** (each with a corresponding unit test):
  - `graphus_search` — semantic RAG search over indexed symbols via `GraphIndexer`
  - `graphus_blast_radius` — BFS traversal of all callers from a given symbol
  - `graphus_callers` — direct callers of a symbol (single-hop)
  - `graphus_callees` — direct callees of a symbol (single-hop)
  - `graphus_module_deps` — Gradle module dependency graph
  - `graphus_hotspots` — files ranked by churn × coupling score
  - `graphus_ownership` — file-to-owner mapping read from `git-analyze` output
- **Server wiring**: `GraphusMcpServer` assembles a `McpSyncServer` over `StdioServerTransportProvider` with all 7 tools registered
- **CLI entry point**: new `serve` picocli subcommand (`ServeCommand`) with `--repo`, `--source`, `--state-dir`, `--db`, and `--embedding` options
- **Auto-install**: `ClaudeCodeMcpSettingsInstaller` writes the `graphus` MCP server entry into `.claude/settings.local.json`; wired into `ClaudeCodeAdapter` so `graphus install claude-code` sets it up automatically
- **Distribution Convention compliance**: `README.md`, `CLAUDE.md`, and `CursorAdapter` updated with the `serve` command in the same change

## Motivation

Until now, AI agents interacting with Graphus-indexed repositories had to shell out to the CLI and parse plain-text output. The MCP server exposes the same capabilities as structured tool calls, giving agents typed inputs and machine-readable JSON responses. This removes the need for any prompt engineering around CLI output and makes the full graph — callers, callees, blast radius, hotspots, ownership — available as first-class tool calls inside Claude Code, Cursor, and any other MCP-compatible agent.

## How to test

1. Build the shadow JAR: `./gradlew build`
2. Index a repository: `java -jar graphus-cli/build/libs/graphus.jar index --repo <path> --db sqlite --embedding local`
3. Start the server manually and verify it accepts tool calls:
   ```
   java -jar graphus-cli/build/libs/graphus.jar serve --repo <path> --db sqlite --embedding local
   ```
4. Run the unit test suite, which covers all 7 tools with mocked contexts:
   ```
   ./gradlew :graphus-cli:test
   ```
5. Install into a Claude Code project and verify `.claude/settings.local.json` gains a `graphus` entry under `mcpServers`:
   ```
   java -jar graphus-cli/build/libs/graphus.jar install claude-code --repo <path>
   ```