### PR TITLE
chore(homebrew): consolidate formula into main repo and fix publish flakiness

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,9 @@ jobs:
       - name: Build
         run: ./gradlew build --no-daemon
 
+      - name: Validate formula syntax
+        run: ruby -c Formula/graphus.rb
+
       - name: Submit dependency graph
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         uses: gradle/actions/dependency-submission@v4

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -44,31 +44,36 @@ jobs:
         env:
           HOMEBREW_TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
           HOMEBREW_TAP_REPO: ${{ vars.HOMEBREW_TAP_REPO }}
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           if [ -z "${HOMEBREW_TAP_TOKEN}" ]; then
-            echo "HOMEBREW_TAP_TOKEN is not set; skipping Homebrew tap update."
-            exit 0
+            echo "::error::HOMEBREW_TAP_TOKEN is not set — Homebrew tap will not be updated."
+            exit 1
           fi
 
           TAG="${{ github.event.release.tag_name }}"
           VERSION="${TAG#v}"
           TAP_REPO="${HOMEBREW_TAP_REPO:-alcantaraleo/homebrew-graphus}"
 
-          echo "Downloading release asset graphus.jar for ${TAG}"
-          gh release download "${TAG}" --repo "${{ github.repository }}" --pattern graphus.jar --dir . --clobber
-          SHA256="$(shasum -a 256 graphus.jar | awk '{print $1}')"
+          # Use the JAR already built in this job — no extra download needed.
+          SHA256="$(shasum -a 256 graphus-cli/build/libs/graphus.jar | awk '{print $1}')"
+          echo "Version: ${VERSION}  SHA256: ${SHA256}"
 
-          echo "Updating Formula/graphus.rb in ${TAP_REPO} with version ${VERSION}"
+          # Render formula from main repo source (Formula/graphus.rb) into a temp file.
+          cp Formula/graphus.rb /tmp/graphus.rb
+          sed -i "s/version \"[^\"]*\"/version \"${VERSION}\"/" /tmp/graphus.rb
+          sed -i "s/sha256 \"[^\"]*\"/sha256 \"${SHA256}\"/" /tmp/graphus.rb
+
+          # Validate Ruby syntax before touching the tap.
+          ruby -c /tmp/graphus.rb
+
+          # Push rendered formula to tap.
           git clone "https://x-access-token:${HOMEBREW_TAP_TOKEN}@github.com/${TAP_REPO}.git" tap-repo
-          perl -0pi -e "s/version \"[^\"]+\"/version \"${VERSION}\"/g; s/sha256 \"[^\"]+\"/sha256 \"${SHA256}\"/g" tap-repo/Formula/graphus.rb
-
+          cp /tmp/graphus.rb tap-repo/Formula/graphus.rb
           cd tap-repo
           if git diff --quiet; then
             echo "Formula unchanged; nothing to commit."
             exit 0
           fi
-
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git add Formula/graphus.rb

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -55,7 +55,7 @@ jobs:
           TAP_REPO="${HOMEBREW_TAP_REPO:-alcantaraleo/homebrew-graphus}"
 
           # Use the JAR already built in this job — no extra download needed.
-          SHA256="$(shasum -a 256 graphus-cli/build/libs/graphus.jar | awk '{print $1}')"
+          SHA256="$(sha256sum graphus-cli/build/libs/graphus.jar | awk '{print $1}')"
           echo "Version: ${VERSION}  SHA256: ${SHA256}"
 
           # Render formula from main repo source (Formula/graphus.rb) into a temp file.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,11 +47,13 @@ Any change to how Graphus is built, packaged, or distributed — including chang
 
 ### Homebrew release flow
 
-- Homebrew distribution uses a separate tap repository (default: `alcantaraleo/homebrew-graphus`).
-- On GitHub Release publish, `.github/workflows/publish.yml` uploads release assets and updates the tap formula (`Formula/graphus.rb`) with:
-  - release version (from tag `vX.Y.Z`)
-  - computed `sha256` of `graphus.jar`
-- Required secret: `HOMEBREW_TAP_TOKEN` with push access to the tap repository.
+- The formula source of truth is `Formula/graphus.rb` in this repo. Edit formula logic here; never edit `alcantaraleo/homebrew-graphus` by hand.
+- On GitHub Release publish, `.github/workflows/publish.yml`:
+  1. Reads `Formula/graphus.rb` from the workspace.
+  2. Substitutes the release version and `sha256` of the built `graphus.jar`.
+  3. Validates Ruby syntax (`ruby -c`).
+  4. Pushes the rendered formula to the `alcantaraleo/homebrew-graphus` tap (a CI-managed mirror).
+- Required secret: `HOMEBREW_TAP_TOKEN` with push access to the tap repository. Missing token now causes a hard CI failure (not a silent skip).
 - Optional repository variable: `HOMEBREW_TAP_REPO` to override the default tap repository.
 
 ## Key Conventions

--- a/Formula/graphus.rb
+++ b/Formula/graphus.rb
@@ -1,0 +1,31 @@
+class Graphus < Formula
+  desc "Java/Spring code graph and RAG CLI"
+  homepage "https://github.com/alcantaraleo/graphus"
+  # version and sha256 are updated automatically by publish.yml on each release.
+  # Edit the formula logic here; do not hand-edit alcantaraleo/homebrew-graphus.
+  version "0.6.0"
+  url "https://github.com/alcantaraleo/graphus/releases/download/v#{version}/graphus.jar"
+  sha256 "c5d98cee20474132df37df8849f9ea8a20dcb23c9dd43c8c5cfbe9ad2229ec60"
+  license "Apache-2.0"
+
+  depends_on "openjdk@21"
+
+  def install
+    libexec.install "graphus.jar"
+
+    bin.mkpath
+    (bin/"graphus").atomic_write <<~EOS
+      #!/bin/sh
+      export JAVA_HOME="${JAVA_HOME:-#{Formula["openjdk@21"].opt_prefix}}"
+      exec "#{Formula["openjdk@21"].opt_bin}/java" -jar "#{libexec}/graphus.jar" "$@"
+    EOS
+    chmod 0755, bin/"graphus"
+  end
+
+  test do
+    output = shell_output("#{bin}/graphus --help")
+    assert_match "Java/Spring code graph + RAG CLI", output
+    assert_match "install", output
+    assert_match "serve", output
+  end
+end

--- a/README.md
+++ b/README.md
@@ -139,16 +139,17 @@ Accepts the same options as `index`. Exits with an error if no checksum registry
 
 ### Homebrew release automation
 
+The formula source of truth is `Formula/graphus.rb` in this repository.
+
 On every GitHub Release publish event, `.github/workflows/publish.yml`:
 
 1. Uploads `graphus.jar` and `graphus` release assets.
-2. Computes SHA-256 for `graphus.jar`.
-3. Updates `Formula/graphus.rb` in the Homebrew tap repo (default `alcantaraleo/homebrew-graphus`) with the release version and checksum.
-4. Commits and pushes the formula bump to the tap.
+2. Reads `Formula/graphus.rb` from the workspace, substitutes the release version and `sha256`, and validates Ruby syntax.
+3. Pushes the rendered formula to the tap repo (default `alcantaraleo/homebrew-graphus`), which is a CI-managed mirror — never edit it directly.
 
 Required GitHub configuration:
 
-- Repository secret: `HOMEBREW_TAP_TOKEN` (PAT with push access to the tap repository)
+- Repository secret: `HOMEBREW_TAP_TOKEN` (PAT with push access to the tap repository) — **required**; missing token now causes a hard CI failure.
 - Optional repository variable: `HOMEBREW_TAP_REPO` (override tap repo; default is `alcantaraleo/homebrew-graphus`)
 
 ### Query Indexed Symbols


### PR DESCRIPTION
## Summary

- Adds `Formula/graphus.rb` to the main repo as the authoritative formula source — formula logic changes now happen via PRs here, never in the tap repo directly
- Adds `ruby -c Formula/graphus.rb` to CI so syntax errors are caught on every PR
- Rewrites the Homebrew tap update step in `publish.yml`: hard failure on missing `HOMEBREW_TAP_TOKEN`, uses in-workspace JAR for SHA256 (no extra download), `sed` substitution instead of fragile `perl`, and `ruby -c` validation before pushing to tap
- Updates `CLAUDE.md` and `README.md` to reflect the new model; updates `alcantaraleo/homebrew-graphus` README to say the tap is CI-managed and should not be hand-edited

Related to #74

## Test Plan

- [ ] CI passes on this PR (formula syntax check runs as part of build)
- [ ] `ruby -c Formula/graphus.rb` passes locally
- [ ] On next release, `publish.yml` reads `Formula/graphus.rb` from workspace, substitutes version/sha256, validates, and pushes to tap — verify `HOMEBREW_TAP_TOKEN` missing now fails loudly rather than silently skipping