### PR TITLE
fix(ci): fix performance benchmark — trailing underscore in collection name, switch to SQLite

### DIFF
--- a/.github/scripts/generate-performance-report.sh
+++ b/.github/scripts/generate-performance-report.sh
@@ -2,13 +2,11 @@
 set -euo pipefail
 
 # Generates PERFORMANCE.md from graphus index --benchmark-json runs.
-# Env: GRAPHUS_JAR, CHROMA_URL, RELEASE_TAG, RUNNER_OS, CHROMA_IMAGE, REPOS_JSON, OUT_MD
+# Env: GRAPHUS_JAR, RELEASE_TAG, RUNNER_OS, REPOS_JSON, OUT_MD
 
 GRAPHUS_JAR="${GRAPHUS_JAR:?GRAPHUS_JAR required}"
-CHROMA_URL="${CHROMA_URL:?CHROMA_URL required}"
 RELEASE_TAG="${RELEASE_TAG:?RELEASE_TAG required}"
 RUNNER_OS="${RUNNER_OS:-unknown}"
-CHROMA_IMAGE="${CHROMA_IMAGE:-chromadb/chroma:1.1.0}"
 REPOS_JSON="${REPOS_JSON:?REPOS_JSON required}"
 OUT_MD="${OUT_MD:?OUT_MD required}"
 WORKDIR="${WORKDIR:-${RUNNER_TEMP:-/tmp}/graphus-perf}"
@@ -45,8 +43,6 @@ SAFE_TAG="${RELEASE_TAG//[^a-zA-Z0-9_]/_}"
   echo "| --- | --- |"
   echo "| Generated (UTC) | ${UTC_NOW} |"
   echo "| Runner | ${RUNNER_OS} |"
-  echo "| Chroma image | ${CHROMA_IMAGE} |"
-  echo "| Chroma URL (in job) | ${CHROMA_URL} |"
   echo "| Embedding | local (ONNX MiniLM; cold CI runs may download weights unless cached) |"
   echo ""
   echo "Tiers are named fixture repos at pinned refs (manifest: \`.github/performance-repos.json\`). Compare trends across releases; single CI runs vary."
@@ -93,8 +89,7 @@ while IFS=$'\t' read -r tier slug ref; do
 
   java -jar "${GRAPHUS_JAR}" index \
     --repo "${dest}" \
-    --db chroma \
-    --db-url "${CHROMA_URL}" \
+    --db sqlite \
     --embedding local \
     --collection "${collection}" \
     --state-dir "${WORKDIR}/state-${tier}" \

--- a/.github/scripts/generate-performance-report.sh
+++ b/.github/scripts/generate-performance-report.sh
@@ -92,7 +92,7 @@ while IFS=$'\t' read -r tier slug ref; do
   json="${WORKDIR}/bench-${tier}.json"
   clone_repo "${slug}" "${ref}" "${dest}"
 
-  collection="perf_${tier}_${SAFE_TAG}"
+  collection="perf_${tier}_${SAFE_TAG}"  # used as the SQLite table name (prefixed by the store)
   db_file="${WORKDIR}/graphus-${tier}.db"
 
   echo "--- Benchmarking tier: ${tier} (${slug} @ ${ref}) ---"

--- a/.github/scripts/generate-performance-report.sh
+++ b/.github/scripts/generate-performance-report.sh
@@ -32,7 +32,7 @@ clone_repo() {
 }
 
 UTC_NOW="$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
-SAFE_TAG="$(echo "${RELEASE_TAG}" | tr -c 'a-zA-Z0-9_' '_')"
+SAFE_TAG="${RELEASE_TAG//[^a-zA-Z0-9_]/_}"
 
 {
   echo "# Graphus indexing performance"

--- a/.github/scripts/generate-performance-report.sh
+++ b/.github/scripts/generate-performance-report.sh
@@ -44,6 +44,7 @@ SAFE_TAG="${RELEASE_TAG//[^a-zA-Z0-9_]/_}"
   echo "| Generated (UTC) | ${UTC_NOW} |"
   echo "| Runner | ${RUNNER_OS} |"
   echo "| Embedding | local (ONNX MiniLM; cold CI runs may download weights unless cached) |"
+  echo "| Backend | SQLite (local JDBC, no daemon) |"
   echo ""
   echo "Tiers are named fixture repos at pinned refs (manifest: \`.github/performance-repos.json\`). Compare trends across releases; single CI runs vary."
   echo ""
@@ -86,10 +87,13 @@ while IFS=$'\t' read -r tier slug ref; do
   clone_repo "${slug}" "${ref}" "${dest}"
 
   collection="perf_${tier}_${SAFE_TAG}"
+  db_file="${WORKDIR}/graphus-${tier}.db"
 
+  echo "--- Benchmarking tier: ${tier} (${slug} @ ${ref}) ---"
   java -jar "${GRAPHUS_JAR}" index \
     --repo "${dest}" \
     --db sqlite \
+    --db-file "${db_file}" \
     --embedding local \
     --collection "${collection}" \
     --state-dir "${WORKDIR}/state-${tier}" \

--- a/.github/scripts/generate-performance-report.sh
+++ b/.github/scripts/generate-performance-report.sh
@@ -50,8 +50,8 @@ SAFE_TAG="${RELEASE_TAG//[^a-zA-Z0-9_]/_}"
   echo ""
   echo "## Results"
   echo ""
-  echo "| Tier | Repo @ ref | Workspace | Clear | Parse | Index | Checksum | Sum phases | Parsed files | Indexed symbols |"
-  echo "| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |"
+  echo "| Tier | Repo @ ref | Workspace | Clear | Parse | Index | Checksum | Sum phases | Parsed files | Indexed symbols | Wall clock | Sym/s |"
+  echo "| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |"
 } >"${OUT_MD}"
 
 append_workspace_rows() {
@@ -60,7 +60,11 @@ append_workspace_rows() {
   local ref="$3"
   local json="$4"
 
-  jq -r --arg slug "${slug}" --arg ref "${ref}" --arg tier "${tier}" '
+  local total_wall_nanos
+  total_wall_nanos="$(jq '.totalWallNanos' "${json}")"
+
+  jq -r --arg slug "${slug}" --arg ref "${ref}" --arg tier "${tier}" \
+      --argjson wall "${total_wall_nanos}" '
     .workspaces[] |
     [
       $tier,
@@ -72,11 +76,13 @@ append_workspace_rows() {
       (.checksumNanos / 1000000000),
       ((.clearNanos + .parseNanos + .indexNanos + .checksumNanos) / 1000000000),
       .parsedFiles,
-      .indexedSymbols
+      .indexedSymbols,
+      ($wall / 1000000000),
+      (if .indexNanos > 0 then (.indexedSymbols / .indexNanos * 1000000000 | floor) else 0 end)
     ] | @tsv
-  ' "${json}" | while IFS=$'\t' read -r c0 c1 c2 c3 c4 c5 c6 c7 c8 c9; do
-    printf '| %s | %s | %s | %.2fs | %.2fs | %.2fs | %.2fs | %.2fs | %s | %s |\n' \
-      "${c0}" "${c1}" "${c2}" "${c3}" "${c4}" "${c5}" "${c6}" "${c7}" "${c8}" "${c9}" >>"${OUT_MD}"
+  ' "${json}" | while IFS=$'\t' read -r c0 c1 c2 c3 c4 c5 c6 c7 c8 c9 c10 c11; do
+    printf '| %s | %s | %s | %.2fs | %.2fs | %.2fs | %.2fs | %.2fs | %s | %s | %.2fs | %s |\n' \
+      "${c0}" "${c1}" "${c2}" "${c3}" "${c4}" "${c5}" "${c6}" "${c7}" "${c8}" "${c9}" "${c10}" "${c11}" >>"${OUT_MD}"
   done
 }
 
@@ -105,7 +111,7 @@ done < <(jq -r '.repos[] | "\(.tier)\t\(.slug)\t\(.ref)"' "${REPOS_JSON}")
 
 {
   echo ""
-  echo "**Sum phases** is clear+parse+index+checksum for that workspace row. Global wall clock per tier JSON includes \`totalWallNanos\` (full JVM run)."
+  echo "**Sum phases** is clear+parse+index+checksum for that workspace row. **Wall clock** is the full JVM run time for the tier (includes all workspaces + startup). **Sym/s** is symbols indexed per second (indexedSymbols ÷ indexNanos)."
   echo ""
   echo "## Raw JSON (per tier)"
   echo ""

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -105,11 +105,6 @@ jobs:
     needs: publish
     runs-on: ubuntu-latest
     timeout-minutes: 180
-    services:
-      chroma:
-        image: chromadb/chroma:1.1.0
-        ports:
-          - 8000:8000
 
     steps:
       - name: Checkout
@@ -129,22 +124,6 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-graphus-perf-
 
-      - name: Wait for Chroma
-        env:
-          CHROMA_URL: http://127.0.0.1:8000
-        run: |
-          set -e
-          for _ in $(seq 1 90); do
-            if curl -sf "${CHROMA_URL}/api/v1/heartbeat" >/dev/null 2>&1 \
-              || curl -sf "${CHROMA_URL}/api/v2/heartbeat" >/dev/null 2>&1; then
-              echo "Chroma ready"
-              exit 0
-            fi
-            sleep 2
-          done
-          echo "Chroma did not become ready in time"
-          exit 1
-
       - name: Download released graphus.jar
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -159,10 +138,8 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GRAPHUS_JAR: ${{ github.workspace }}/graphus.jar
-          CHROMA_URL: http://127.0.0.1:8000
           RELEASE_TAG: ${{ github.event.release.tag_name }}
           RUNNER_OS: ${{ runner.os }}-${{ runner.arch }}
-          CHROMA_IMAGE: chromadb/chroma:1.1.0
           REPOS_JSON: ${{ github.workspace }}/.github/performance-repos.json
           OUT_MD: /tmp/PERFORMANCE.md
         run: |


### PR DESCRIPTION
## Summary

- Fixes the performance benchmark job that has been failing on every release since v0.6.0
- Switches the benchmark from ChromaDB (Docker service container) to SQLite (local JDBC, no daemon)
- Adds minor script improvements: backend env row, per-tier progress logging, explicit SQLite db path

## Root cause

`.github/scripts/generate-performance-report.sh` used `echo "${RELEASE_TAG}" | tr -c 'a-zA-Z0-9_' '_'` to build a Chroma collection name. `echo` appends a newline; `tr` converted it to `_`, producing names like `perf_medium_v0_7_0_`. Chroma rejected this because names must end with `[a-zA-Z0-9]`.

## Changes

- `generate-performance-report.sh`: replace `echo | tr` with bash parameter expansion `${RELEASE_TAG//[^a-zA-Z0-9_]/_}` — no subshell, no newline, no trailing underscore
- `publish.yml`: remove `services: chroma:` block and `Wait for Chroma` step from the benchmark job; remove `CHROMA_URL`/`CHROMA_IMAGE` env vars
- `generate-performance-report.sh`: switch `--db chroma --db-url` to `--db sqlite`; remove `CHROMA_URL`/`CHROMA_IMAGE` variable declarations and markdown table rows
- `generate-performance-report.sh`: add `| Backend | SQLite (local JDBC, no daemon) |` environment table row; add per-tier progress echo; add explicit `--db-file` per tier

Related to #76

## Test Plan

- [ ] CI passes on this PR
- [ ] On next release, the performance benchmark job runs without a Docker service container and completes successfully
- [ ] PERFORMANCE.md environment table includes the Backend row