### PR TITLE
fix(parser): support Groovy quoted-string include syntax in GradleSettingsParser

### DIFF
--- a/graphus-parser/src/main/java/io/graphus/parser/GradleSettingsParser.java
+++ b/graphus-parser/src/main/java/io/graphus/parser/GradleSettingsParser.java
@@ -24,6 +24,15 @@ public final class GradleSettingsParser {
 
     private static final Pattern QUOTED_TOKEN = Pattern.compile("[\"']([^\"']+)[\"']");
 
+    /**
+     * Matches the Groovy space-call form: {@code include "a:b"} or {@code include 'a', 'b'}.
+     * The negative lookahead {@code (?!\()} excludes the parenthesised form which is already
+     * handled by {@link #INCLUDE_BLOCK}.
+     */
+    private static final Pattern INCLUDE_SPACE_FORM = Pattern.compile(
+            "(?m)^[ \\t]*include[ \\t]+(?!\\()([^\\n]+)"
+    );
+
     private GradleSettingsParser() {
     }
 
@@ -49,6 +58,19 @@ public final class GradleSettingsParser {
                 }
             }
         }
+
+        Matcher spaceMatcher = INCLUDE_SPACE_FORM.matcher(stripped);
+        while (spaceMatcher.find()) {
+            String tail = spaceMatcher.group(1);
+            Matcher tokenMatcher = QUOTED_TOKEN.matcher(tail);
+            while (tokenMatcher.find()) {
+                String normalized = gradleIncludeToRelativePath(tokenMatcher.group(1));
+                if (!normalized.isEmpty()) {
+                    orderedUnique.add(normalized);
+                }
+            }
+        }
+
         return List.copyOf(orderedUnique);
     }
 

--- a/graphus-parser/src/test/java/io/graphus/parser/GradleSettingsParserTest.java
+++ b/graphus-parser/src/test/java/io/graphus/parser/GradleSettingsParserTest.java
@@ -43,4 +43,56 @@ class GradleSettingsParserTest {
                 lineWithTrailingComment.indexOf("//"),
                 GradleSettingsParser.lineCommentStart(lineWithTrailingComment));
     }
+
+    @Test
+    void parsesGroovySpaceFormDoubleQuote(@TempDir Path tempDir) throws IOException {
+        Path file = tempDir.resolve("settings.gradle");
+        Files.writeString(file, """
+                rootProject.name = "spring-boot"
+                include "spring-boot-project:spring-boot"
+                include "spring-boot-project:spring-boot-tools:spring-boot-buildpack-platform"
+                """);
+        assertEquals(
+                List.of(
+                        "spring-boot-project/spring-boot",
+                        "spring-boot-project/spring-boot-tools/spring-boot-buildpack-platform"),
+                GradleSettingsParser.parseModuleNames(file));
+    }
+
+    @Test
+    void parsesGroovySpaceFormSingleQuote(@TempDir Path tempDir) throws IOException {
+        Path file = tempDir.resolve("settings.gradle");
+        Files.writeString(file, """
+                include 'core'
+                include 'api', 'web'
+                """);
+        assertEquals(
+                List.of("core", "api", "web"),
+                GradleSettingsParser.parseModuleNames(file));
+    }
+
+    @Test
+    void parsesGroovySpaceFormSingleQuoteWithColonSeparator(@TempDir Path tempDir) throws IOException {
+        Path file = tempDir.resolve("settings.gradle");
+        Files.writeString(file, """
+                include ':services:payments'
+                """);
+        assertEquals(
+                List.of("services/payments"),
+                GradleSettingsParser.parseModuleNames(file));
+    }
+
+    @Test
+    void mixedParenthesisedAndSpaceFormDeduplicates(@TempDir Path tempDir) throws IOException {
+        Path file = tempDir.resolve("settings.gradle");
+        Files.writeString(file, """
+                include("core")
+                include "api"
+                // include "commented-out"
+                include 'web'
+                """);
+        assertEquals(
+                List.of("core", "api", "web"),
+                GradleSettingsParser.parseModuleNames(file));
+    }
 }


### PR DESCRIPTION
## Summary

- Adds `INCLUDE_SPACE_FORM` pattern to `GradleSettingsParser` recognising the unparenthesised Groovy `include "x:y"` and `include 'a', 'b'` forms
- Results are accumulated via the same `LinkedHashSet`-backed deduplication path as the existing parenthesised form, preserving insertion order
- Parenthesised form (`include("x")`) is excluded from the new pattern via a negative lookahead `(?!\()`

## Test plan

- [ ] `parsesGroovySpaceFormDoubleQuote` — double-quoted modules with colon-separated paths
- [ ] `parsesGroovySpaceFormSingleQuote` — single-quoted modules including multi-argument line
- [ ] `parsesGroovySpaceFormSingleQuoteWithColonSeparator` — single-quote with `:x:y` path normalisation
- [ ] `mixedParenthesisedAndSpaceFormDeduplicates` — both syntaxes in same file, commented line excluded

Related to #50