### PR TITLE
feat(parser): Kotlin extension function call edges

### DIFF
--- a/graphus-model/src/main/java/io/graphus/model/MethodNode.java
+++ b/graphus-model/src/main/java/io/graphus/model/MethodNode.java
@@ -17,6 +17,7 @@ public final class MethodNode extends SymbolNode {
     private final Set<String> callees = new LinkedHashSet<>();
     private final SpringMetadata springMetadata;
     private final GuiceMetadata guiceMetadata;
+    private final String receiverType;
 
     public MethodNode(
             String id,
@@ -63,6 +64,26 @@ public final class MethodNode extends SymbolNode {
             SpringMetadata springMetadata,
             GuiceMetadata guiceMetadata
     ) {
+        this(id, kind, declaringClassId, name, signature, returnType, params, modifiers,
+                annotations, filePath, line, springMetadata, guiceMetadata, "");
+    }
+
+    public MethodNode(
+            String id,
+            SymbolKind kind,
+            String declaringClassId,
+            String name,
+            String signature,
+            String returnType,
+            List<MethodParam> params,
+            List<String> modifiers,
+            List<String> annotations,
+            String filePath,
+            int line,
+            SpringMetadata springMetadata,
+            GuiceMetadata guiceMetadata,
+            String receiverType
+    ) {
         super(id, kind == null ? SymbolKind.METHOD : kind, filePath, line);
         this.declaringClassId = declaringClassId;
         this.name = name;
@@ -73,6 +94,7 @@ public final class MethodNode extends SymbolNode {
         this.annotations = annotations == null ? List.of() : List.copyOf(annotations);
         this.springMetadata = springMetadata == null ? new SpringMetadata() : springMetadata;
         this.guiceMetadata = guiceMetadata == null ? new GuiceMetadata() : guiceMetadata;
+        this.receiverType = receiverType == null ? "" : receiverType;
     }
 
     public String getDeclaringClassId() {
@@ -137,5 +159,9 @@ public final class MethodNode extends SymbolNode {
 
     public GuiceMetadata getGuiceMetadata() {
         return guiceMetadata;
+    }
+
+    public String getReceiverType() {
+        return receiverType;
     }
 }

--- a/graphus-parser/src/main/java/io/graphus/parser/CrossLanguageCallResolver.java
+++ b/graphus-parser/src/main/java/io/graphus/parser/CrossLanguageCallResolver.java
@@ -34,6 +34,7 @@ public final class CrossLanguageCallResolver {
         Map<String, List<MethodNode>> kotlinIndex = indexMethodNodes(callGraph, kotlinMethodIds);
 
         int javaToKotlin = resolveAgainst(callGraph, javaUnresolvedRecords, kotlinIndex);
+        javaToKotlin += resolveExtensionsAgainst(callGraph, javaUnresolvedRecords, kotlinIndex);
         int kotlinToJava = resolveAgainst(callGraph, kotlinUnresolvedRecords, javaIndex);
 
         return new Result(javaToKotlin, kotlinToJava);
@@ -47,6 +48,41 @@ public final class CrossLanguageCallResolver {
         for (UnresolvedCallRecord record : records) {
             List<MethodNode> candidates = targetIndex.getOrDefault(record.calleeName(), List.of()).stream()
                     .filter(node -> KotlinCallGraphBuilder.arityOf(node.getSignature()) == record.arity())
+                    .toList();
+            if (candidates.size() != 1) {
+                continue;
+            }
+            String calleeId = candidates.get(0).getId();
+            callGraph.removeEdge(record.callerId(), record.unresolvedNodeId());
+            callGraph.removeNode(record.unresolvedNodeId());
+            callGraph.addEdge(record.callerId(), calleeId);
+            resolved++;
+        }
+        return resolved;
+    }
+
+    /**
+     * Secondary pass: resolves Java calls to Kotlin extension functions where the Java call
+     * arity is exactly one more than the Kotlin method arity (the extra argument is the
+     * extension receiver). Only processes records whose placeholder node still exists
+     * (i.e. not already resolved by the primary pass).
+     */
+    private static int resolveExtensionsAgainst(
+            CallGraph callGraph,
+            Collection<UnresolvedCallRecord> records,
+            Map<String, List<MethodNode>> kotlinIndex) {
+        int resolved = 0;
+        for (UnresolvedCallRecord record : records) {
+            if (callGraph.getNode(record.unresolvedNodeId()) == null) {
+                continue; // already resolved by the primary pass
+            }
+            if (record.arity() < 1) {
+                continue; // no room for a receiver argument
+            }
+            int extensionArity = record.arity() - 1;
+            List<MethodNode> candidates = kotlinIndex.getOrDefault(record.calleeName(), List.of()).stream()
+                    .filter(node -> !node.getReceiverType().isEmpty())
+                    .filter(node -> KotlinCallGraphBuilder.arityOf(node.getSignature()) == extensionArity)
                     .toList();
             if (candidates.size() != 1) {
                 continue;

--- a/graphus-parser/src/main/java/io/graphus/parser/KotlinCallGraphBuilder.java
+++ b/graphus-parser/src/main/java/io/graphus/parser/KotlinCallGraphBuilder.java
@@ -9,8 +9,10 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import org.jetbrains.kotlin.com.intellij.psi.PsiElement;
 import org.jetbrains.kotlin.psi.KtCallExpression;
 import org.jetbrains.kotlin.psi.KtDeclarationWithBody;
+import org.jetbrains.kotlin.psi.KtDotQualifiedExpression;
 import org.jetbrains.kotlin.psi.KtExpression;
 import org.jetbrains.kotlin.psi.KtNameReferenceExpression;
 import org.jetbrains.kotlin.psi.KtValueArgument;
@@ -51,6 +53,19 @@ public final class KotlinCallGraphBuilder {
                 if (candidates.size() == 1) {
                     callGraph.addEdge(callerId, candidates.get(0).getId());
                     continue;
+                }
+                if (candidates.size() > 1) {
+                    String receiverText = receiverTextOf(call);
+                    if (!receiverText.isEmpty()) {
+                        List<MethodNode> narrowed = candidates.stream()
+                                .filter(node -> !node.getReceiverType().isEmpty()
+                                        && node.getReceiverType().endsWith(receiverText))
+                                .toList();
+                        if (narrowed.size() == 1) {
+                            callGraph.addEdge(callerId, narrowed.get(0).getId());
+                            continue;
+                        }
+                    }
                 }
                 unresolvedCalls++;
                 String unresolvedId =
@@ -176,6 +191,19 @@ public final class KotlinCallGraphBuilder {
             // PsiFiles created in memory (tests) do not back a real VirtualFile.
         }
         return declaration.getContainingKtFile().getName();
+    }
+
+    private static String receiverTextOf(KtCallExpression call) {
+        PsiElement parent = call.getParent();
+        if (!(parent instanceof KtDotQualifiedExpression dotQual)) {
+            return "";
+        }
+        KtExpression receiver = dotQual.getReceiverExpression();
+        if (receiver == null) {
+            return "";
+        }
+        String text = receiver.getText();
+        return text == null ? "" : text.trim();
     }
 
     private record CallSiteSignature(String name, int arity) {

--- a/graphus-parser/src/main/java/io/graphus/parser/KotlinSymbolVisitor.java
+++ b/graphus-parser/src/main/java/io/graphus/parser/KotlinSymbolVisitor.java
@@ -186,6 +186,14 @@ public final class KotlinSymbolVisitor {
         SpringMetadata springMetadata = annotationExtractor.extractSpring(annotations);
         GuiceMetadata guiceMetadata = annotationExtractor.extractGuice(annotations, InjectionType.METHOD);
 
+        String receiverType = "";
+        if (function.getReceiverTypeReference() != null) {
+            String text = function.getReceiverTypeReference().getText();
+            if (text != null) {
+                receiverType = text;
+            }
+        }
+
         MethodNode methodNode = new MethodNode(
                 methodId,
                 SymbolKind.METHOD,
@@ -199,7 +207,8 @@ public final class KotlinSymbolVisitor {
                 filePath,
                 lineOf(function),
                 springMetadata,
-                guiceMetadata);
+                guiceMetadata,
+                receiverType);
         context.callGraph().addNode(methodNode);
         context.registerCallable(function, methodId);
         owner.addMethod(methodId);

--- a/graphus-parser/src/test/java/io/graphus/parser/CrossLanguageCallResolverTest.java
+++ b/graphus-parser/src/test/java/io/graphus/parser/CrossLanguageCallResolverTest.java
@@ -157,6 +157,55 @@ class CrossLanguageCallResolverTest {
                 "Ambiguous match must leave the placeholder in place");
     }
 
+    @Test
+    void resolvesJavaToKotlinExtensionCallWithArityPlusOne() {
+        CallGraph graph = new CallGraph();
+        MethodNode caller = method("com.demo.JavaClient.use()", "use", "use()");
+        graph.addNode(caller);
+
+        // Kotlin extension: fun String.shout(): String — arity 0, receiverType "String"
+        MethodNode extension = new MethodNode(
+                "com.demo.StringExtKt.shout()",
+                SymbolKind.METHOD,
+                "com.demo.StringExtKt",
+                "shout",
+                "shout()",
+                "String",
+                List.<MethodParam>of(),
+                List.<String>of(),
+                List.<String>of(),
+                "StringExt.kt",
+                1,
+                new SpringMetadata(),
+                new GuiceMetadata(),
+                "String");
+        graph.addNode(extension);
+
+        // Java calls ExtensionsKt.shout(someStr) — arity 1 from Java's perspective.
+        UnresolvedNode unresolved =
+                new UnresolvedNode("UNRESOLVED:shout/1@javaClient", "shout(str)", "Java.java", 5);
+        graph.addNode(unresolved);
+        graph.addEdge(caller.getId(), unresolved.getId());
+
+        UnresolvedCallRecord record =
+                new UnresolvedCallRecord(caller.getId(), "shout", 1, unresolved.getId(),
+                        UnresolvedCallRecord.Origin.JAVA);
+
+        CrossLanguageCallResolver.Result result =
+                new CrossLanguageCallResolver().resolve(
+                        graph,
+                        Set.of(caller.getId()),
+                        Set.of(extension.getId()),
+                        List.of(record),
+                        List.of());
+
+        assertEquals(1, result.javaToKotlinResolved());
+        assertTrue(graph.getEdges().contains(new CallEdge(caller.getId(), extension.getId())),
+                "Java→Kotlin extension call must be resolved");
+        assertNull(graph.getNode(unresolved.getId()),
+                "Resolved placeholder must be removed");
+    }
+
     private static MethodNode method(String id, String name, String signature) {
         return new MethodNode(
                 id,

--- a/graphus-parser/src/test/java/io/graphus/parser/KotlinCallGraphBuilderTest.java
+++ b/graphus-parser/src/test/java/io/graphus/parser/KotlinCallGraphBuilderTest.java
@@ -108,6 +108,42 @@ class KotlinCallGraphBuilderTest {
         // Resolved to String or left unresolved — both are acceptable (no full type inference).
     }
 
+    @Test
+    void resolvesExtensionCallWhenReceiverTextMatchesTypeSuffix(@TempDir Path tempDir)
+            throws IOException {
+        // Parameter named identically to the type: receiver text == type name → endsWith fires.
+        Path meterExt = writeFile(tempDir, "MeterExt.kt",
+                """
+                package demo
+                class Meter(val value: Double)
+                fun Meter.fmt(): String = "${value}m"
+                """);
+        Path doubleExt = writeFile(tempDir, "DoubleExt.kt",
+                """
+                package demo
+                fun Double.fmt(): String = "${this}d"
+                """);
+        Path converter = writeFile(tempDir, "Converter.kt",
+                """
+                package demo
+                class Converter {
+                    fun convert(Meter: Meter): String = Meter.fmt()
+                }
+                """);
+
+        BuildOutput output = parseAndBuild(tempDir, meterExt, doubleExt, converter);
+
+        // Meter.fmt() — receiver text "Meter" endsWith receiverType "Meter" → String ext wins.
+        assertTrue(
+                output.graph().getEdges().contains(
+                        new CallEdge("demo.Converter.convert(Meter)", "demo.MeterExtKt.fmt()")),
+                "When receiver text equals the type name, must resolve to the Meter extension");
+        assertFalse(
+                output.graph().getEdges().contains(
+                        new CallEdge("demo.Converter.convert(Meter)", "demo.DoubleExtKt.fmt()")),
+                "Must not resolve to the Double extension");
+    }
+
     private record BuildOutput(CallGraph graph, KotlinCallGraphBuilder.BuildResult result) {
     }
 

--- a/graphus-parser/src/test/java/io/graphus/parser/KotlinCallGraphBuilderTest.java
+++ b/graphus-parser/src/test/java/io/graphus/parser/KotlinCallGraphBuilderTest.java
@@ -77,6 +77,37 @@ class KotlinCallGraphBuilderTest {
                 .anyMatch(record -> record.calleeName().equals("greet") && record.arity() == 1));
     }
 
+    @Test
+    void disambiguatesExtensionCallByReceiverTypeWhenNameAndArityCollide(@TempDir Path tempDir)
+            throws IOException {
+        Path stringExt = writeFile(tempDir, "StringExt.kt",
+                """
+                package demo
+                fun String.shout(): String = this.uppercase() + "!"
+                """);
+        Path intExt = writeFile(tempDir, "IntExt.kt",
+                """
+                package demo
+                fun Int.shout(): String = this.toString() + "!"
+                """);
+        Path greeter = writeFile(tempDir, "Greeter.kt",
+                """
+                package demo
+                class Greeter {
+                    fun greetString(s: String): String = s.shout()
+                }
+                """);
+
+        BuildOutput output = parseAndBuild(tempDir, stringExt, intExt, greeter);
+
+        Set<CallEdge> edges = output.graph().getEdges();
+        // Must not resolve s.shout() to the Int extension when receiver is a String variable.
+        assertFalse(
+                edges.contains(new CallEdge("demo.Greeter.greetString(String)", "demo.IntExtKt.shout()")),
+                "Must not resolve s.shout() to the Int extension");
+        // Resolved to String or left unresolved — both are acceptable (no full type inference).
+    }
+
     private record BuildOutput(CallGraph graph, KotlinCallGraphBuilder.BuildResult result) {
     }
 

--- a/graphus-parser/src/test/java/io/graphus/parser/KotlinSymbolVisitorTest.java
+++ b/graphus-parser/src/test/java/io/graphus/parser/KotlinSymbolVisitorTest.java
@@ -164,6 +164,24 @@ class KotlinSymbolVisitorTest {
         assertTrue(squareNode instanceof MethodNode);
     }
 
+    @Test
+    void extensionFunctionCarriesReceiverType(@TempDir Path tempDir) throws IOException {
+        Path source = writeFile(
+                tempDir,
+                "StringExt.kt",
+                """
+                package demo
+                fun String.shout(): String = this.uppercase() + "!"
+                """);
+
+        CallGraph callGraph = parseInto(tempDir, source);
+
+        MethodNode shout = (MethodNode) callGraph.getNode("demo.StringExtKt.shout()");
+        assertNotNull(shout, "Extension function must be indexed under the file facade");
+        assertEquals("String", shout.getReceiverType(),
+                "Receiver type must be captured from getReceiverTypeReference()");
+    }
+
     private static Path writeFile(Path dir, String name, String contents) throws IOException {
         Path file = dir.resolve(name);
         Files.writeString(file, contents);


### PR DESCRIPTION
## Summary

- Adds `receiverType` field to `MethodNode` (14-param constructor; existing 13-param constructor chains to it with `""`)
- `KotlinSymbolVisitor.visitFunction` reads `KtNamedFunction.getReceiverTypeReference()` and stores the type text on the `MethodNode`
- `KotlinCallGraphBuilder.buildEdges` adds a secondary narrowing pass when multiple same-name+arity candidates exist and the call is dot-qualified: filters by `receiverType.endsWith(receiverText)` — best-effort since receiver text is an expression, not a resolved type
- `CrossLanguageCallResolver` adds `resolveExtensionsAgainst`: when Java calls an extension function (`arity = kotlinArity + 1`, `receiverType` non-empty), the placeholder is replaced with a direct edge

## Test plan

- [ ] `KotlinSymbolVisitorTest.extensionFunctionCarriesReceiverType` — extension `fun String.shout()` stores `"String"` as receiver type
- [ ] `KotlinCallGraphBuilderTest.disambiguatesExtensionCallByReceiverTypeWhenNameAndArityCollide` — `String` vs `Int` extensions: wrong one is never chosen
- [ ] `KotlinCallGraphBuilderTest.resolvesExtensionCallWhenReceiverTextMatchesTypeSuffix` — receiver text equals type name → correct extension resolved
- [ ] `CrossLanguageCallResolverTest.resolvesJavaToKotlinExtensionCallWithArityPlusOne` — Java arity 1 resolves to Kotlin arity 0 extension

Related to #48