### PR TITLE
feat(parser): resolve Kotlin operator overloads and tag lambda invocations as call edges

### DIFF
--- a/graphus-parser/src/main/java/io/graphus/parser/KotlinCallGraphBuilder.java
+++ b/graphus-parser/src/main/java/io/graphus/parser/KotlinCallGraphBuilder.java
@@ -14,6 +14,9 @@ import org.jetbrains.kotlin.psi.KtCallExpression;
 import org.jetbrains.kotlin.psi.KtDeclarationWithBody;
 import org.jetbrains.kotlin.psi.KtExpression;
 import org.jetbrains.kotlin.psi.KtNameReferenceExpression;
+import org.jetbrains.kotlin.psi.KtPostfixExpression;
+import org.jetbrains.kotlin.psi.KtPrefixExpression;
+import org.jetbrains.kotlin.psi.KtUnaryExpression;
 import org.jetbrains.kotlin.psi.KtValueArgument;
 
 /**
@@ -27,6 +30,14 @@ import org.jetbrains.kotlin.psi.KtValueArgument;
  * {@link CrossLanguageCallResolver} can attempt Kotlin→Java resolution in a later pass.
  */
 public final class KotlinCallGraphBuilder {
+
+    private static final Map<String, String> UNARY_OPERATOR_TO_METHOD = Map.of(
+            "PLUS", "unaryPlus",
+            "MINUS", "unaryMinus",
+            "EXCL", "not",
+            "PLUSPLUS", "inc",
+            "MINUSMINUS", "dec"
+    );
 
     private static final Map<String, String> BINARY_OPERATOR_TO_METHOD = Map.ofEntries(
             Map.entry("PLUS", "plus"),
@@ -111,6 +122,20 @@ public final class KotlinCallGraphBuilder {
                             UnresolvedCallRecord.Origin.KOTLIN));
                 }
             }
+            for (KtPrefixExpression prefix : findAllPrefixExpressions(body)) {
+                String tokenName = prefix.getOperationToken().toString();
+                String methodName = UNARY_OPERATOR_TO_METHOD.get(tokenName);
+                if (methodName == null) continue;
+                unresolvedCalls += resolveUnaryOperator(callGraph, callerId, declaration, prefix,
+                        methodName, kotlinMethodsByName, records);
+            }
+            for (KtPostfixExpression postfix : findAllPostfixExpressions(body)) {
+                String tokenName = postfix.getOperationToken().toString();
+                String methodName = UNARY_OPERATOR_TO_METHOD.get(tokenName);
+                if (methodName == null) continue;
+                unresolvedCalls += resolveUnaryOperator(callGraph, callerId, declaration, postfix,
+                        methodName, kotlinMethodsByName, records);
+            }
         }
 
         return new BuildResult(unresolvedCalls, List.copyOf(records));
@@ -148,6 +173,55 @@ public final class KotlinCallGraphBuilder {
                 .findChildrenOfType(root, KtBinaryExpression.class)
                 .forEach(result::add);
         return result;
+    }
+
+    private static List<KtPrefixExpression> findAllPrefixExpressions(KtExpression root) {
+        List<KtPrefixExpression> result = new ArrayList<>();
+        if (root instanceof KtPrefixExpression r) {
+            result.add(r);
+        }
+        org.jetbrains.kotlin.com.intellij.psi.util.PsiTreeUtil
+                .findChildrenOfType(root, KtPrefixExpression.class)
+                .forEach(result::add);
+        return result;
+    }
+
+    private static List<KtPostfixExpression> findAllPostfixExpressions(KtExpression root) {
+        List<KtPostfixExpression> result = new ArrayList<>();
+        if (root instanceof KtPostfixExpression r) {
+            result.add(r);
+        }
+        org.jetbrains.kotlin.com.intellij.psi.util.PsiTreeUtil
+                .findChildrenOfType(root, KtPostfixExpression.class)
+                .forEach(result::add);
+        return result;
+    }
+
+    private static int resolveUnaryOperator(
+            CallGraph callGraph,
+            String callerId,
+            KtDeclarationWithBody declaration,
+            KtUnaryExpression unary,
+            String methodName,
+            Map<String, List<MethodNode>> kotlinMethodsByName,
+            List<UnresolvedCallRecord> records) {
+        List<MethodNode> candidates = kotlinMethodsByName.getOrDefault(methodName, List.of()).stream()
+                .filter(node -> arityOf(node.getSignature()) == 0)
+                .toList();
+        if (candidates.size() == 1) {
+            callGraph.addEdge(callerId, candidates.get(0).getId());
+            return 0;
+        } else if (!candidates.isEmpty()) {
+            String unresolvedId = "UNRESOLVED:OP:" + methodName + "/0@" + callerId
+                    + "#" + System.identityHashCode(unary);
+            callGraph.addNode(new UnresolvedNode(
+                    unresolvedId, unary.getText(), relativeFilePathOf(declaration), lineOf(unary)));
+            callGraph.addEdge(callerId, unresolvedId);
+            records.add(new UnresolvedCallRecord(callerId, methodName, 0, unresolvedId,
+                    UnresolvedCallRecord.Origin.KOTLIN));
+            return 1;
+        }
+        return 0;
     }
 
     private static CallSiteSignature signatureOf(KtCallExpression call) {

--- a/graphus-parser/src/main/java/io/graphus/parser/KotlinCallGraphBuilder.java
+++ b/graphus-parser/src/main/java/io/graphus/parser/KotlinCallGraphBuilder.java
@@ -9,6 +9,7 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import org.jetbrains.kotlin.psi.KtBinaryExpression;
 import org.jetbrains.kotlin.psi.KtCallExpression;
 import org.jetbrains.kotlin.psi.KtDeclarationWithBody;
 import org.jetbrains.kotlin.psi.KtExpression;
@@ -26,6 +27,25 @@ import org.jetbrains.kotlin.psi.KtValueArgument;
  * {@link CrossLanguageCallResolver} can attempt Kotlin→Java resolution in a later pass.
  */
 public final class KotlinCallGraphBuilder {
+
+    private static final Map<String, String> BINARY_OPERATOR_TO_METHOD = Map.ofEntries(
+            Map.entry("PLUS", "plus"),
+            Map.entry("MINUS", "minus"),
+            Map.entry("MUL", "times"),
+            Map.entry("DIV", "div"),
+            Map.entry("PERC", "rem"),
+            Map.entry("PLUSEQ", "plusAssign"),
+            Map.entry("MINUSEQ", "minusAssign"),
+            Map.entry("MULTEQ", "timesAssign"),
+            Map.entry("DIVEQ", "divAssign"),
+            Map.entry("PERCEQ", "remAssign"),
+            Map.entry("EQEQ", "equals"),
+            Map.entry("LT", "compareTo"),
+            Map.entry("GT", "compareTo"),
+            Map.entry("LTEQ", "compareTo"),
+            Map.entry("GTEQ", "compareTo"),
+            Map.entry("RANGE", "rangeTo")
+    );
 
     public BuildResult buildEdges(CallGraph callGraph, KotlinParserContext context) {
         Map<String, List<MethodNode>> kotlinMethodsByName = indexKotlinMethods(callGraph, context);
@@ -67,6 +87,30 @@ public final class KotlinCallGraphBuilder {
                         unresolvedId,
                         UnresolvedCallRecord.Origin.KOTLIN));
             }
+            for (KtBinaryExpression binary : findAllBinaryExpressions(body)) {
+                String tokenName = binary.getOperationToken().toString();
+                String methodName = BINARY_OPERATOR_TO_METHOD.get(tokenName);
+                if (methodName == null) {
+                    continue;
+                }
+                // Binary operators always take one argument (the right-hand side).
+                List<MethodNode> candidates = kotlinMethodsByName.getOrDefault(methodName, List.of()).stream()
+                        .filter(node -> arityOf(node.getSignature()) == 1)
+                        .toList();
+                if (candidates.size() == 1) {
+                    callGraph.addEdge(callerId, candidates.get(0).getId());
+                } else if (!candidates.isEmpty()) {
+                    unresolvedCalls++;
+                    String unresolvedId = "UNRESOLVED:OP:" + methodName + "/1@" + callerId
+                            + "#" + System.identityHashCode(binary);
+                    String filePath = relativeFilePathOf(declaration);
+                    int line = lineOf(binary);
+                    callGraph.addNode(new UnresolvedNode(unresolvedId, binary.getText(), filePath, line));
+                    callGraph.addEdge(callerId, unresolvedId);
+                    records.add(new UnresolvedCallRecord(callerId, methodName, 1, unresolvedId,
+                            UnresolvedCallRecord.Origin.KOTLIN));
+                }
+            }
         }
 
         return new BuildResult(unresolvedCalls, List.copyOf(records));
@@ -93,6 +137,17 @@ public final class KotlinCallGraphBuilder {
                 .findChildrenOfType(root, KtCallExpression.class)
                 .forEach(calls::add);
         return calls;
+    }
+
+    private static List<KtBinaryExpression> findAllBinaryExpressions(KtExpression root) {
+        List<KtBinaryExpression> result = new ArrayList<>();
+        if (root instanceof KtBinaryExpression rootBin) {
+            result.add(rootBin);
+        }
+        org.jetbrains.kotlin.com.intellij.psi.util.PsiTreeUtil
+                .findChildrenOfType(root, KtBinaryExpression.class)
+                .forEach(result::add);
+        return result;
     }
 
     private static CallSiteSignature signatureOf(KtCallExpression call) {
@@ -153,14 +208,14 @@ public final class KotlinCallGraphBuilder {
         return count;
     }
 
-    private static int lineOf(KtCallExpression call) {
+    private static int lineOf(org.jetbrains.kotlin.psi.KtElement element) {
         org.jetbrains.kotlin.com.intellij.openapi.editor.Document document =
-                org.jetbrains.kotlin.com.intellij.psi.PsiDocumentManager.getInstance(call.getProject())
-                        .getDocument(call.getContainingKtFile());
-        if (document == null || call.getTextRange() == null) {
+                org.jetbrains.kotlin.com.intellij.psi.PsiDocumentManager.getInstance(element.getProject())
+                        .getDocument(element.getContainingKtFile());
+        if (document == null || element.getTextRange() == null) {
             return -1;
         }
-        return document.getLineNumber(call.getTextRange().getStartOffset()) + 1;
+        return document.getLineNumber(element.getTextRange().getStartOffset()) + 1;
     }
 
     private static String relativeFilePathOf(KtDeclarationWithBody declaration) {

--- a/graphus-parser/src/main/java/io/graphus/parser/KotlinCallGraphBuilder.java
+++ b/graphus-parser/src/main/java/io/graphus/parser/KotlinCallGraphBuilder.java
@@ -9,6 +9,7 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import org.jetbrains.kotlin.psi.KtArrayAccessExpression;
 import org.jetbrains.kotlin.psi.KtBinaryExpression;
 import org.jetbrains.kotlin.psi.KtCallExpression;
 import org.jetbrains.kotlin.psi.KtDeclarationWithBody;
@@ -136,6 +137,28 @@ public final class KotlinCallGraphBuilder {
                 unresolvedCalls += resolveUnaryOperator(callGraph, callerId, declaration, postfix,
                         methodName, kotlinMethodsByName, records);
             }
+            for (KtArrayAccessExpression arrayAccess : findAllArrayAccesses(body)) {
+                int indexCount = arrayAccess.getIndexExpressions().size();
+                boolean isWrite = isLhsOfAssignment(arrayAccess);
+                String methodName = isWrite ? "set" : "get";
+                int arity = isWrite ? indexCount + 1 : indexCount;
+                List<MethodNode> candidates = kotlinMethodsByName.getOrDefault(methodName, List.of()).stream()
+                        .filter(node -> arityOf(node.getSignature()) == arity)
+                        .toList();
+                if (candidates.size() == 1) {
+                    callGraph.addEdge(callerId, candidates.get(0).getId());
+                } else if (!candidates.isEmpty()) {
+                    unresolvedCalls++;
+                    String unresolvedId = "UNRESOLVED:OP:" + methodName + "/" + arity + "@" + callerId
+                            + "#" + System.identityHashCode(arrayAccess);
+                    callGraph.addNode(new UnresolvedNode(
+                            unresolvedId, arrayAccess.getText(),
+                            relativeFilePathOf(declaration), lineOf(arrayAccess)));
+                    callGraph.addEdge(callerId, unresolvedId);
+                    records.add(new UnresolvedCallRecord(callerId, methodName, arity, unresolvedId,
+                            UnresolvedCallRecord.Origin.KOTLIN));
+                }
+            }
         }
 
         return new BuildResult(unresolvedCalls, List.copyOf(records));
@@ -195,6 +218,26 @@ public final class KotlinCallGraphBuilder {
                 .findChildrenOfType(root, KtPostfixExpression.class)
                 .forEach(result::add);
         return result;
+    }
+
+    private static List<KtArrayAccessExpression> findAllArrayAccesses(KtExpression root) {
+        List<KtArrayAccessExpression> result = new ArrayList<>();
+        if (root instanceof KtArrayAccessExpression r) {
+            result.add(r);
+        }
+        org.jetbrains.kotlin.com.intellij.psi.util.PsiTreeUtil
+                .findChildrenOfType(root, KtArrayAccessExpression.class)
+                .forEach(result::add);
+        return result;
+    }
+
+    private static boolean isLhsOfAssignment(KtArrayAccessExpression arrayAccess) {
+        org.jetbrains.kotlin.com.intellij.psi.PsiElement parent = arrayAccess.getParent();
+        if (!(parent instanceof KtBinaryExpression binary)) {
+            return false;
+        }
+        return "EQ".equals(binary.getOperationToken().toString())
+                && binary.getLeft() == arrayAccess;
     }
 
     private static int resolveUnaryOperator(

--- a/graphus-parser/src/main/java/io/graphus/parser/KotlinCallGraphBuilder.java
+++ b/graphus-parser/src/main/java/io/graphus/parser/KotlinCallGraphBuilder.java
@@ -7,6 +7,7 @@ import io.graphus.model.UnresolvedNode;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -75,6 +76,7 @@ public final class KotlinCallGraphBuilder {
             if (body == null) {
                 continue;
             }
+            Set<String> lambdaParams = functionTypeParameterNames(declaration);
             for (KtCallExpression call : findAllCallExpressions(body)) {
                 CallSiteSignature signature = signatureOf(call);
                 if (signature == null) {
@@ -89,7 +91,6 @@ public final class KotlinCallGraphBuilder {
                     continue;
                 }
                 unresolvedCalls++;
-                Set<String> lambdaParams = functionTypeParameterNames(declaration);
                 boolean isLambdaInvocation = lambdaParams.contains(signature.name());
                 String tag = isLambdaInvocation ? "UNRESOLVED:LAMBDA:" : "UNRESOLVED:";
                 String unresolvedId =
@@ -361,7 +362,7 @@ public final class KotlinCallGraphBuilder {
         if (!(declaration instanceof KtNamedFunction function)) {
             return Set.of();
         }
-        Set<String> names = new java.util.LinkedHashSet<>();
+        Set<String> names = new HashSet<>();
         for (KtParameter parameter : function.getValueParameters()) {
             if (parameter.getTypeReference() != null
                     && parameter.getTypeReference().getTypeElement() instanceof KtFunctionType) {

--- a/graphus-parser/src/main/java/io/graphus/parser/KotlinCallGraphBuilder.java
+++ b/graphus-parser/src/main/java/io/graphus/parser/KotlinCallGraphBuilder.java
@@ -9,12 +9,16 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import org.jetbrains.kotlin.psi.KtArrayAccessExpression;
 import org.jetbrains.kotlin.psi.KtBinaryExpression;
 import org.jetbrains.kotlin.psi.KtCallExpression;
 import org.jetbrains.kotlin.psi.KtDeclarationWithBody;
 import org.jetbrains.kotlin.psi.KtExpression;
+import org.jetbrains.kotlin.psi.KtFunctionType;
 import org.jetbrains.kotlin.psi.KtNameReferenceExpression;
+import org.jetbrains.kotlin.psi.KtNamedFunction;
+import org.jetbrains.kotlin.psi.KtParameter;
 import org.jetbrains.kotlin.psi.KtPostfixExpression;
 import org.jetbrains.kotlin.psi.KtPrefixExpression;
 import org.jetbrains.kotlin.psi.KtUnaryExpression;
@@ -85,8 +89,11 @@ public final class KotlinCallGraphBuilder {
                     continue;
                 }
                 unresolvedCalls++;
+                Set<String> lambdaParams = functionTypeParameterNames(declaration);
+                boolean isLambdaInvocation = lambdaParams.contains(signature.name());
+                String tag = isLambdaInvocation ? "UNRESOLVED:LAMBDA:" : "UNRESOLVED:";
                 String unresolvedId =
-                        "UNRESOLVED:" + signature.name() + "/" + signature.arity() + "@" + callerId
+                        tag + signature.name() + "/" + signature.arity() + "@" + callerId
                                 + "#" + System.identityHashCode(call);
                 String filePath = relativeFilePathOf(declaration);
                 int line = lineOf(call);
@@ -348,6 +355,23 @@ public final class KotlinCallGraphBuilder {
             // PsiFiles created in memory (tests) do not back a real VirtualFile.
         }
         return declaration.getContainingKtFile().getName();
+    }
+
+    private static Set<String> functionTypeParameterNames(KtDeclarationWithBody declaration) {
+        if (!(declaration instanceof KtNamedFunction function)) {
+            return Set.of();
+        }
+        Set<String> names = new java.util.LinkedHashSet<>();
+        for (KtParameter parameter : function.getValueParameters()) {
+            if (parameter.getTypeReference() != null
+                    && parameter.getTypeReference().getTypeElement() instanceof KtFunctionType) {
+                String name = parameter.getName();
+                if (name != null && !name.isBlank()) {
+                    names.add(name);
+                }
+            }
+        }
+        return names;
     }
 
     private record CallSiteSignature(String name, int arity) {

--- a/graphus-parser/src/test/java/io/graphus/parser/KotlinCallGraphBuilderTest.java
+++ b/graphus-parser/src/test/java/io/graphus/parser/KotlinCallGraphBuilderTest.java
@@ -121,6 +121,28 @@ class KotlinCallGraphBuilderTest {
                 "Prefix '++' must resolve to operator fun inc()");
     }
 
+    @Test
+    void resolvesArrayAccessGetOperatorAsCallEdge(@TempDir Path tempDir) throws IOException {
+        Path source = writeFile(
+                tempDir,
+                "Grid.kt",
+                """
+                package demo
+
+                class Grid {
+                    operator fun get(row: Int, col: Int): Int = row * 10 + col
+                    fun diagonal(i: Int): Int = this[i, i]
+                }
+                """);
+
+        BuildOutput output = parseAndBuild(tempDir, source);
+
+        assertTrue(
+                output.graph().getEdges().contains(
+                        new CallEdge("demo.Grid.diagonal(Int)", "demo.Grid.get(Int, Int)")),
+                "Array access this[i, i] must resolve to operator fun get(Int, Int)");
+    }
+
     private record BuildOutput(CallGraph graph, KotlinCallGraphBuilder.BuildResult result) {
     }
 

--- a/graphus-parser/src/test/java/io/graphus/parser/KotlinCallGraphBuilderTest.java
+++ b/graphus-parser/src/test/java/io/graphus/parser/KotlinCallGraphBuilderTest.java
@@ -77,6 +77,28 @@ class KotlinCallGraphBuilderTest {
                 .anyMatch(record -> record.calleeName().equals("greet") && record.arity() == 1));
     }
 
+    @Test
+    void resolvesBinaryOperatorOverloadAsCallEdge(@TempDir Path tempDir) throws IOException {
+        Path source = writeFile(
+                tempDir,
+                "Vector.kt",
+                """
+                package demo
+
+                data class Vector(val x: Int, val y: Int) {
+                    operator fun plus(other: Vector): Vector = Vector(x + other.x, y + other.y)
+                    fun combine(other: Vector): Vector = this + other
+                }
+                """);
+
+        BuildOutput output = parseAndBuild(tempDir, source);
+
+        assertTrue(
+                output.graph().getEdges().contains(
+                        new CallEdge("demo.Vector.combine(Vector)", "demo.Vector.plus(Vector)")),
+                "Binary '+' on Vector must resolve to operator fun plus(Vector)");
+    }
+
     private record BuildOutput(CallGraph graph, KotlinCallGraphBuilder.BuildResult result) {
     }
 

--- a/graphus-parser/src/test/java/io/graphus/parser/KotlinCallGraphBuilderTest.java
+++ b/graphus-parser/src/test/java/io/graphus/parser/KotlinCallGraphBuilderTest.java
@@ -144,6 +144,30 @@ class KotlinCallGraphBuilderTest {
     }
 
     @Test
+    void resolvesArrayAccessSetOperatorAsCallEdge(@TempDir Path tempDir) throws IOException {
+        Path source = writeFile(
+                tempDir,
+                "Bag.kt",
+                """
+                package demo
+
+                class Bag {
+                    private val data = mutableMapOf<Int, Int>()
+                    operator fun get(i: Int): Int = data[i] ?: 0
+                    operator fun set(i: Int, v: Int) { data[i] = v }
+                    fun fill(i: Int) { this[i] = 42 }
+                }
+                """);
+
+        BuildOutput output = parseAndBuild(tempDir, source);
+
+        assertTrue(
+                output.graph().getEdges().contains(
+                        new CallEdge("demo.Bag.fill(Int)", "demo.Bag.set(Int, Int)")),
+                "Array write this[i] = 42 must resolve to operator fun set(Int, Int)");
+    }
+
+    @Test
     void lambdaParameterInvocationProducesTaggedUnresolvedNode(@TempDir Path tempDir) throws IOException {
         Path source = writeFile(
                 tempDir,

--- a/graphus-parser/src/test/java/io/graphus/parser/KotlinCallGraphBuilderTest.java
+++ b/graphus-parser/src/test/java/io/graphus/parser/KotlinCallGraphBuilderTest.java
@@ -143,6 +143,26 @@ class KotlinCallGraphBuilderTest {
                 "Array access this[i, i] must resolve to operator fun get(Int, Int)");
     }
 
+    @Test
+    void lambdaParameterInvocationProducesTaggedUnresolvedNode(@TempDir Path tempDir) throws IOException {
+        Path source = writeFile(
+                tempDir,
+                "Processor.kt",
+                """
+                package demo
+
+                fun process(handler: (String) -> String, input: String): String = handler(input)
+                """);
+
+        BuildOutput output = parseAndBuild(tempDir, source);
+
+        // The call handler(input) should produce a tagged UNRESOLVED:LAMBDA: node.
+        boolean hasLambdaUnresolved = output.graph().getNodes().stream()
+                .anyMatch(node -> node.getId().startsWith("UNRESOLVED:LAMBDA:handler"));
+        assertTrue(hasLambdaUnresolved,
+                "Lambda parameter invocation must produce an UNRESOLVED:LAMBDA: tagged node");
+    }
+
     private record BuildOutput(CallGraph graph, KotlinCallGraphBuilder.BuildResult result) {
     }
 

--- a/graphus-parser/src/test/java/io/graphus/parser/KotlinCallGraphBuilderTest.java
+++ b/graphus-parser/src/test/java/io/graphus/parser/KotlinCallGraphBuilderTest.java
@@ -99,6 +99,28 @@ class KotlinCallGraphBuilderTest {
                 "Binary '+' on Vector must resolve to operator fun plus(Vector)");
     }
 
+    @Test
+    void resolvesUnaryOperatorOverloadAsCallEdge(@TempDir Path tempDir) throws IOException {
+        Path source = writeFile(
+                tempDir,
+                "Counter.kt",
+                """
+                package demo
+
+                class Counter(var value: Int) {
+                    operator fun inc(): Counter = Counter(value + 1)
+                    fun step(): Counter { var c = this; return ++c }
+                }
+                """);
+
+        BuildOutput output = parseAndBuild(tempDir, source);
+
+        assertTrue(
+                output.graph().getEdges().contains(
+                        new CallEdge("demo.Counter.step()", "demo.Counter.inc()")),
+                "Prefix '++' must resolve to operator fun inc()");
+    }
+
     private record BuildOutput(CallGraph graph, KotlinCallGraphBuilder.BuildResult result) {
     }
 


### PR DESCRIPTION
## Summary

- Adds binary operator overload resolution (`a + b`, `a == b`, `a..b`, etc.) — 16 operators mapped to their Kotlin convention method names via `BINARY_OPERATOR_TO_METHOD`
- Adds prefix and postfix unary operator resolution (`++x`, `x++`, `!x`, etc.) — 5 operators via `UNARY_OPERATOR_TO_METHOD`
- Adds array-access operator resolution (`a[i]` → `get`, `a[i] = v` → `set`) with correct arity counting
- Tags lambda parameter invocations (`handler(input)` where `handler: (T) -> R`) as `UNRESOLVED:LAMBDA:` instead of plain `UNRESOLVED:`, preventing false cross-language resolution attempts

## Test Plan

- [ ] `resolvesBinaryOperatorOverloadAsCallEdge` — `combine` calling `this + other` resolves to `plus(Vector)`
- [ ] `resolvesUnaryOperatorOverloadAsCallEdge` — `step()` calling `++c` resolves to `inc()`
- [ ] `resolvesArrayAccessGetOperatorAsCallEdge` — `diagonal(i)` calling `this[i, i]` resolves to `get(Int, Int)`
- [ ] `resolvesArrayAccessSetOperatorAsCallEdge` — `fill(i)` calling `this[i] = 42` resolves to `set(Int, Int)`
- [ ] `lambdaParameterInvocationProducesTaggedUnresolvedNode` — `handler(input)` produces `UNRESOLVED:LAMBDA:handler` node
- [ ] Full build passes: `./gradlew build --no-daemon`

Related to #49