### PR TITLE
fix(cli): route progress bar output to stderr for MCP serve

### DIFF
--- a/graphus-cli/src/main/java/io/graphus/cli/IndexProgressReporter.java
+++ b/graphus-cli/src/main/java/io/graphus/cli/IndexProgressReporter.java
@@ -32,13 +32,13 @@ public final class IndexProgressReporter implements IndexProgressListener {
         int paddingLength = Math.max(0, previousLineLength - line.length());
         String padding = " ".repeat(paddingLength);
 
-        System.out.print("\r" + line + padding);
+        System.err.print("\r" + line + padding);
         previousLineLength = line.length();
     }
 
     public void complete() {
         if (previousLineLength > 0) {
-            System.out.println();
+            System.err.println();
         }
     }
 

--- a/graphus-cli/src/main/java/io/graphus/cli/ParserProgressReporter.java
+++ b/graphus-cli/src/main/java/io/graphus/cli/ParserProgressReporter.java
@@ -31,13 +31,13 @@ public final class ParserProgressReporter implements ParseProgressListener {
         int paddingLength = Math.max(0, previousLineLength - line.length());
         String padding = " ".repeat(paddingLength);
 
-        System.out.print("\r" + line + padding);
+        System.err.print("\r" + line + padding);
         previousLineLength = line.length();
     }
 
     public void complete() {
         if (previousLineLength > 0) {
-            System.out.println();
+            System.err.println();
         }
     }
 }

--- a/graphus-cli/src/test/java/io/graphus/cli/IndexProgressReporterTest.java
+++ b/graphus-cli/src/test/java/io/graphus/cli/IndexProgressReporterTest.java
@@ -6,9 +6,9 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import dev.langchain4j.data.document.Metadata;
 import io.graphus.indexer.IndexProgressListener;
 import io.graphus.indexer.SymbolChunk;
-import java.util.Map;
 import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
+import java.util.Map;
 import org.junit.jupiter.api.Test;
 
 class IndexProgressReporterTest {
@@ -17,11 +17,12 @@ class IndexProgressReporterTest {
     void onSymbolStartWritesNothingWhenTotalIsZero() {
         IndexProgressListener reporter = new IndexProgressReporter();
         ByteArrayOutputStream captured = new ByteArrayOutputStream();
+        PrintStream originalErr = System.err;
         System.setErr(new PrintStream(captured));
         try {
             reporter.onSymbolStart(makeChunk("test.txt"), 0, 0);
         } finally {
-            System.setErr(System.err);
+            System.setErr(originalErr);
         }
         assertEquals(0, captured.size());
     }
@@ -30,12 +31,12 @@ class IndexProgressReporterTest {
     void onSymbolStartProducesOutputOnStderr() {
         IndexProgressReporter reporter = new IndexProgressReporter();
         ByteArrayOutputStream captured = new ByteArrayOutputStream();
-        var errStream = new PrintStream(captured);
-        System.setErr(errStream);
+        PrintStream originalErr = System.err;
+        System.setErr(new PrintStream(captured));
         try {
             reporter.onSymbolStart(makeChunk("com/example/Symbol.java"), 1, 2);
         } finally {
-            System.setErr(System.err);
+            System.setErr(originalErr);
         }
         assertTrue(captured.size() > 0);
     }
@@ -44,12 +45,12 @@ class IndexProgressReporterTest {
     void onSymbolStartHandlesCurrentEqualToTotal() {
         IndexProgressReporter reporter = new IndexProgressReporter();
         ByteArrayOutputStream captured = new ByteArrayOutputStream();
-        var errStream = new PrintStream(captured);
-        System.setErr(errStream);
+        PrintStream originalErr = System.err;
+        System.setErr(new PrintStream(captured));
         try {
             reporter.onSymbolStart(makeChunk("com/example/Symbol.java"), 5, 5);
         } finally {
-            System.setErr(System.err);
+            System.setErr(originalErr);
         }
         assertTrue(captured.size() > 0);
     }
@@ -58,12 +59,12 @@ class IndexProgressReporterTest {
     void onSymbolStartClampsCurrentBounded() {
         IndexProgressReporter reporter = new IndexProgressReporter();
         ByteArrayOutputStream captured = new ByteArrayOutputStream();
-        var errStream = new PrintStream(captured);
-        System.setErr(errStream);
+        PrintStream originalErr = System.err;
+        System.setErr(new PrintStream(captured));
         try {
             reporter.onSymbolStart(makeChunk("com/example/Symbol.java"), 999, 10);
         } finally {
-            System.setErr(System.err);
+            System.setErr(originalErr);
         }
         assertTrue(captured.size() > 0);
     }
@@ -72,13 +73,13 @@ class IndexProgressReporterTest {
     void completePrintsNewlineAfterProgress() {
         IndexProgressReporter reporter = new IndexProgressReporter();
         ByteArrayOutputStream captured = new ByteArrayOutputStream();
-        var errStream = new PrintStream(captured);
-        System.setErr(errStream);
+        PrintStream originalErr = System.err;
+        System.setErr(new PrintStream(captured));
         try {
             reporter.onSymbolStart(makeChunk("com/example/Symbol.java"), 1, 2);
             reporter.complete();
         } finally {
-            System.setErr(System.err);
+            System.setErr(originalErr);
         }
         String output = captured.toString();
         assertTrue(output.contains("\r"), "Should contain carriage return for in-place overwrite");
@@ -88,12 +89,12 @@ class IndexProgressReporterTest {
     void completeDoesNothingWhenNoProgressShown() {
         IndexProgressReporter reporter = new IndexProgressReporter();
         ByteArrayOutputStream captured = new ByteArrayOutputStream();
-        var errStream = new PrintStream(captured);
-        System.setErr(errStream);
+        PrintStream originalErr = System.err;
+        System.setErr(new PrintStream(captured));
         try {
             reporter.complete();
         } finally {
-            System.setErr(System.err);
+            System.setErr(originalErr);
         }
         assertEquals(0, captured.size(), "complete() with no prior progress should produce no output");
     }
@@ -102,8 +103,8 @@ class IndexProgressReporterTest {
     void resolveTargetUsesFileMetadata() {
         IndexProgressReporter reporter = new IndexProgressReporter();
         ByteArrayOutputStream captured = new ByteArrayOutputStream();
-        var errStream = new PrintStream(captured);
-        System.setErr(errStream);
+        PrintStream originalErr = System.err;
+        System.setErr(new PrintStream(captured));
         try {
             SymbolChunk chunk = new SymbolChunk(
                     "com.example.MyClass#method()",
@@ -111,7 +112,7 @@ class IndexProgressReporterTest {
                     new Metadata(Map.of("file", "src/main/java/com/example/MyClass.java")));
             reporter.onSymbolStart(chunk, 1, 1);
         } finally {
-            System.setErr(System.err);
+            System.setErr(originalErr);
         }
         String output = captured.toString();
         assertTrue(output.contains("src/main/java/com/example/MyClass.java"),
@@ -122,8 +123,8 @@ class IndexProgressReporterTest {
     void resolveTargetFallsBackToSymbolId() {
         IndexProgressReporter reporter = new IndexProgressReporter();
         ByteArrayOutputStream captured = new ByteArrayOutputStream();
-        var errStream = new PrintStream(captured);
-        System.setErr(errStream);
+        PrintStream originalErr = System.err;
+        System.setErr(new PrintStream(captured));
         try {
             SymbolChunk chunk = new SymbolChunk(
                     "com.example.MyClass#method()",
@@ -131,7 +132,7 @@ class IndexProgressReporterTest {
                     new Metadata());
             reporter.onSymbolStart(chunk, 1, 1);
         } finally {
-            System.setErr(System.err);
+            System.setErr(originalErr);
         }
         String output = captured.toString();
         assertTrue(output.contains("com.example.MyClass#method()"),

--- a/graphus-cli/src/test/java/io/graphus/cli/IndexProgressReporterTest.java
+++ b/graphus-cli/src/test/java/io/graphus/cli/IndexProgressReporterTest.java
@@ -1,0 +1,144 @@
+package io.graphus.cli;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import dev.langchain4j.data.document.Metadata;
+import io.graphus.indexer.IndexProgressListener;
+import io.graphus.indexer.SymbolChunk;
+import java.util.Map;
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import org.junit.jupiter.api.Test;
+
+class IndexProgressReporterTest {
+
+    @Test
+    void onSymbolStartWritesNothingWhenTotalIsZero() {
+        IndexProgressListener reporter = new IndexProgressReporter();
+        ByteArrayOutputStream captured = new ByteArrayOutputStream();
+        System.setErr(new PrintStream(captured));
+        try {
+            reporter.onSymbolStart(makeChunk("test.txt"), 0, 0);
+        } finally {
+            System.setErr(System.err);
+        }
+        assertEquals(0, captured.size());
+    }
+
+    @Test
+    void onSymbolStartProducesOutputOnStderr() {
+        IndexProgressReporter reporter = new IndexProgressReporter();
+        ByteArrayOutputStream captured = new ByteArrayOutputStream();
+        var errStream = new PrintStream(captured);
+        System.setErr(errStream);
+        try {
+            reporter.onSymbolStart(makeChunk("com/example/Symbol.java"), 1, 2);
+        } finally {
+            System.setErr(System.err);
+        }
+        assertTrue(captured.size() > 0);
+    }
+
+    @Test
+    void onSymbolStartHandlesCurrentEqualToTotal() {
+        IndexProgressReporter reporter = new IndexProgressReporter();
+        ByteArrayOutputStream captured = new ByteArrayOutputStream();
+        var errStream = new PrintStream(captured);
+        System.setErr(errStream);
+        try {
+            reporter.onSymbolStart(makeChunk("com/example/Symbol.java"), 5, 5);
+        } finally {
+            System.setErr(System.err);
+        }
+        assertTrue(captured.size() > 0);
+    }
+
+    @Test
+    void onSymbolStartClampsCurrentBounded() {
+        IndexProgressReporter reporter = new IndexProgressReporter();
+        ByteArrayOutputStream captured = new ByteArrayOutputStream();
+        var errStream = new PrintStream(captured);
+        System.setErr(errStream);
+        try {
+            reporter.onSymbolStart(makeChunk("com/example/Symbol.java"), 999, 10);
+        } finally {
+            System.setErr(System.err);
+        }
+        assertTrue(captured.size() > 0);
+    }
+
+    @Test
+    void completePrintsNewlineAfterProgress() {
+        IndexProgressReporter reporter = new IndexProgressReporter();
+        ByteArrayOutputStream captured = new ByteArrayOutputStream();
+        var errStream = new PrintStream(captured);
+        System.setErr(errStream);
+        try {
+            reporter.onSymbolStart(makeChunk("com/example/Symbol.java"), 1, 2);
+            reporter.complete();
+        } finally {
+            System.setErr(System.err);
+        }
+        String output = captured.toString();
+        assertTrue(output.contains("\r"), "Should contain carriage return for in-place overwrite");
+    }
+
+    @Test
+    void completeDoesNothingWhenNoProgressShown() {
+        IndexProgressReporter reporter = new IndexProgressReporter();
+        ByteArrayOutputStream captured = new ByteArrayOutputStream();
+        var errStream = new PrintStream(captured);
+        System.setErr(errStream);
+        try {
+            reporter.complete();
+        } finally {
+            System.setErr(System.err);
+        }
+        assertEquals(0, captured.size(), "complete() with no prior progress should produce no output");
+    }
+
+    @Test
+    void resolveTargetUsesFileMetadata() {
+        IndexProgressReporter reporter = new IndexProgressReporter();
+        ByteArrayOutputStream captured = new ByteArrayOutputStream();
+        var errStream = new PrintStream(captured);
+        System.setErr(errStream);
+        try {
+            SymbolChunk chunk = new SymbolChunk(
+                    "com.example.MyClass#method()",
+                    "method body",
+                    new Metadata(Map.of("file", "src/main/java/com/example/MyClass.java")));
+            reporter.onSymbolStart(chunk, 1, 1);
+        } finally {
+            System.setErr(System.err);
+        }
+        String output = captured.toString();
+        assertTrue(output.contains("src/main/java/com/example/MyClass.java"),
+                "Should use file metadata as target");
+    }
+
+    @Test
+    void resolveTargetFallsBackToSymbolId() {
+        IndexProgressReporter reporter = new IndexProgressReporter();
+        ByteArrayOutputStream captured = new ByteArrayOutputStream();
+        var errStream = new PrintStream(captured);
+        System.setErr(errStream);
+        try {
+            SymbolChunk chunk = new SymbolChunk(
+                    "com.example.MyClass#method()",
+                    "method body",
+                    new Metadata());
+            reporter.onSymbolStart(chunk, 1, 1);
+        } finally {
+            System.setErr(System.err);
+        }
+        String output = captured.toString();
+        assertTrue(output.contains("com.example.MyClass#method()"),
+                "Should fall back to symbol id when no file metadata");
+    }
+
+    private SymbolChunk makeChunk(String target) {
+        return new SymbolChunk(target, "text", new Metadata());
+    }
+}

--- a/graphus-cli/src/test/java/io/graphus/cli/ParserProgressReporterTest.java
+++ b/graphus-cli/src/test/java/io/graphus/cli/ParserProgressReporterTest.java
@@ -1,0 +1,114 @@
+package io.graphus.cli;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.nio.file.FileSystems;
+import org.junit.jupiter.api.Test;
+
+class ParserProgressReporterTest {
+
+    @Test
+    void onFileStartWritesNothingWhenTotalIsZero() {
+        var reporter = new ParserProgressReporter();
+        ByteArrayOutputStream captured = new ByteArrayOutputStream();
+        System.setErr(new PrintStream(captured));
+        try {
+            reporter.onFileStart(FileSystems.getDefault().getPath("Test.java"), 0, 0);
+        } finally {
+            System.setErr(System.err);
+        }
+        assertEquals(0, captured.size());
+    }
+
+    @Test
+    void onFileStartProducesOutputOnStderr() {
+        var reporter = new ParserProgressReporter();
+        ByteArrayOutputStream captured = new ByteArrayOutputStream();
+        var errStream = new PrintStream(captured);
+        System.setErr(errStream);
+        try {
+            reporter.onFileStart(FileSystems.getDefault().getPath("com/example/Foo.java"), 1, 2);
+        } finally {
+            System.setErr(System.err);
+        }
+        assertTrue(captured.size() > 0);
+    }
+
+    @Test
+    void onFileStartHandlesCurrentEqualToTotal() {
+        var reporter = new ParserProgressReporter();
+        ByteArrayOutputStream captured = new ByteArrayOutputStream();
+        var errStream = new PrintStream(captured);
+        System.setErr(errStream);
+        try {
+            reporter.onFileStart(FileSystems.getDefault().getPath("com/example/Foo.java"), 5, 5);
+        } finally {
+            System.setErr(System.err);
+        }
+        assertTrue(captured.size() > 0);
+    }
+
+    @Test
+    void onFileStartClampsCurrentBounded() {
+        var reporter = new ParserProgressReporter();
+        ByteArrayOutputStream captured = new ByteArrayOutputStream();
+        var errStream = new PrintStream(captured);
+        System.setErr(errStream);
+        try {
+            reporter.onFileStart(FileSystems.getDefault().getPath("com/example/Foo.java"), 999, 10);
+        } finally {
+            System.setErr(System.err);
+        }
+        assertTrue(captured.size() > 0);
+    }
+
+    @Test
+    void completePrintsNewlineAfterProgress() {
+        var reporter = new ParserProgressReporter();
+        ByteArrayOutputStream captured = new ByteArrayOutputStream();
+        var errStream = new PrintStream(captured);
+        System.setErr(errStream);
+        try {
+            reporter.onFileStart(FileSystems.getDefault().getPath("com/example/Foo.java"), 1, 2);
+            reporter.complete();
+        } finally {
+            System.setErr(System.err);
+        }
+        String output = captured.toString();
+        assertTrue(output.contains("\r"), "Should contain carriage return for in-place overwrite");
+    }
+
+    @Test
+    void completeDoesNothingWhenNoProgressShown() {
+        var reporter = new ParserProgressReporter();
+        ByteArrayOutputStream captured = new ByteArrayOutputStream();
+        var errStream = new PrintStream(captured);
+        System.setErr(errStream);
+        try {
+            reporter.complete();
+        } finally {
+            System.setErr(System.err);
+        }
+        assertEquals(0, captured.size(), "complete() with no prior progress should produce no output");
+    }
+
+    @Test
+    void onFileStartIsIdempotentWithPadding() {
+        var reporter = new ParserProgressReporter();
+        ByteArrayOutputStream captured = new ByteArrayOutputStream();
+        var errStream = new PrintStream(captured);
+        System.setErr(errStream);
+        try {
+            reporter.onFileStart(FileSystems.getDefault().getPath("com/example/Foo.java"), 1, 10);
+            int firstLength = captured.size();
+            reporter.onFileStart(FileSystems.getDefault().getPath("com/example/Foo.java"), 2, 10);
+            int secondLength = captured.size();
+            assertTrue(secondLength >= firstLength);
+        } finally {
+            System.setErr(System.err);
+        }
+    }
+}

--- a/graphus-cli/src/test/java/io/graphus/cli/ParserProgressReporterTest.java
+++ b/graphus-cli/src/test/java/io/graphus/cli/ParserProgressReporterTest.java
@@ -14,11 +14,12 @@ class ParserProgressReporterTest {
     void onFileStartWritesNothingWhenTotalIsZero() {
         var reporter = new ParserProgressReporter();
         ByteArrayOutputStream captured = new ByteArrayOutputStream();
+        PrintStream originalErr = System.err;
         System.setErr(new PrintStream(captured));
         try {
             reporter.onFileStart(FileSystems.getDefault().getPath("Test.java"), 0, 0);
         } finally {
-            System.setErr(System.err);
+            System.setErr(originalErr);
         }
         assertEquals(0, captured.size());
     }
@@ -27,12 +28,12 @@ class ParserProgressReporterTest {
     void onFileStartProducesOutputOnStderr() {
         var reporter = new ParserProgressReporter();
         ByteArrayOutputStream captured = new ByteArrayOutputStream();
-        var errStream = new PrintStream(captured);
-        System.setErr(errStream);
+        PrintStream originalErr = System.err;
+        System.setErr(new PrintStream(captured));
         try {
             reporter.onFileStart(FileSystems.getDefault().getPath("com/example/Foo.java"), 1, 2);
         } finally {
-            System.setErr(System.err);
+            System.setErr(originalErr);
         }
         assertTrue(captured.size() > 0);
     }
@@ -41,12 +42,12 @@ class ParserProgressReporterTest {
     void onFileStartHandlesCurrentEqualToTotal() {
         var reporter = new ParserProgressReporter();
         ByteArrayOutputStream captured = new ByteArrayOutputStream();
-        var errStream = new PrintStream(captured);
-        System.setErr(errStream);
+        PrintStream originalErr = System.err;
+        System.setErr(new PrintStream(captured));
         try {
             reporter.onFileStart(FileSystems.getDefault().getPath("com/example/Foo.java"), 5, 5);
         } finally {
-            System.setErr(System.err);
+            System.setErr(originalErr);
         }
         assertTrue(captured.size() > 0);
     }
@@ -55,12 +56,12 @@ class ParserProgressReporterTest {
     void onFileStartClampsCurrentBounded() {
         var reporter = new ParserProgressReporter();
         ByteArrayOutputStream captured = new ByteArrayOutputStream();
-        var errStream = new PrintStream(captured);
-        System.setErr(errStream);
+        PrintStream originalErr = System.err;
+        System.setErr(new PrintStream(captured));
         try {
             reporter.onFileStart(FileSystems.getDefault().getPath("com/example/Foo.java"), 999, 10);
         } finally {
-            System.setErr(System.err);
+            System.setErr(originalErr);
         }
         assertTrue(captured.size() > 0);
     }
@@ -69,13 +70,13 @@ class ParserProgressReporterTest {
     void completePrintsNewlineAfterProgress() {
         var reporter = new ParserProgressReporter();
         ByteArrayOutputStream captured = new ByteArrayOutputStream();
-        var errStream = new PrintStream(captured);
-        System.setErr(errStream);
+        PrintStream originalErr = System.err;
+        System.setErr(new PrintStream(captured));
         try {
             reporter.onFileStart(FileSystems.getDefault().getPath("com/example/Foo.java"), 1, 2);
             reporter.complete();
         } finally {
-            System.setErr(System.err);
+            System.setErr(originalErr);
         }
         String output = captured.toString();
         assertTrue(output.contains("\r"), "Should contain carriage return for in-place overwrite");
@@ -85,12 +86,12 @@ class ParserProgressReporterTest {
     void completeDoesNothingWhenNoProgressShown() {
         var reporter = new ParserProgressReporter();
         ByteArrayOutputStream captured = new ByteArrayOutputStream();
-        var errStream = new PrintStream(captured);
-        System.setErr(errStream);
+        PrintStream originalErr = System.err;
+        System.setErr(new PrintStream(captured));
         try {
             reporter.complete();
         } finally {
-            System.setErr(System.err);
+            System.setErr(originalErr);
         }
         assertEquals(0, captured.size(), "complete() with no prior progress should produce no output");
     }
@@ -99,8 +100,8 @@ class ParserProgressReporterTest {
     void onFileStartIsIdempotentWithPadding() {
         var reporter = new ParserProgressReporter();
         ByteArrayOutputStream captured = new ByteArrayOutputStream();
-        var errStream = new PrintStream(captured);
-        System.setErr(errStream);
+        PrintStream originalErr = System.err;
+        System.setErr(new PrintStream(captured));
         try {
             reporter.onFileStart(FileSystems.getDefault().getPath("com/example/Foo.java"), 1, 10);
             int firstLength = captured.size();
@@ -108,7 +109,7 @@ class ParserProgressReporterTest {
             int secondLength = captured.size();
             assertTrue(secondLength >= firstLength);
         } finally {
-            System.setErr(System.err);
+            System.setErr(originalErr);
         }
     }
 }


### PR DESCRIPTION
## Problem

`graphus serve` is non-functional. Progress bars are written to **stdout**, which corrupts the MCP JSON-RPC channel.

### Root Cause

`ParserProgressReporter.java` and `IndexProgressReporter.java` both write `\r`-prefixed progress bars to `System.out`. The MCP STDIO transport uses stdout exclusively for JSON-RPC messages. Any non-JSON bytes on stdout break the protocol.

### Reproduction

```bash
echo '{"jsonrpc":"2.0","id":1,"method":"initialize",...}' | java -jar graphus.jar serve --repo . --db sqlite
# stdout receives 31 KB of \r + progress bar noise. No JSON-RPC response.
```

## Fix

Change `System.out` → `System.err` in both progress reporters.

- `graphus-cli/src/main/java/io/graphus/cli/ParserProgressReporter.java` lines 34, 40
- `graphus-cli/src/main/java/io/graphus/cli/IndexProgressReporter.java` lines 35, 41

`System.err` is the correct stream for CLI progress output. It remains visible in a terminal and doesn't contaminate the MCP channel. The `serve` command's diagnostic messages already follow this convention (all use `System.err`).

## Changes

- `graphus-cli/src/main/java/io/graphus/cli/ParserProgressReporter.java` — 2 changed
- `graphus-cli/src/main/java/io/graphus/cli/IndexProgressReporter.java` — 2 changed
- `graphus-cli/src/test/java/io/graphus/cli/ParserProgressReporterTest.java` — new
- `graphus-cli/src/test/java/io/graphus/cli/IndexProgressReporterTest.java` — new

## Tests

Unit tests verify:
- Progress output lands on stderr (not stdout)
- Zero-total and boundary conditions produce correct behavior
- `complete()` no-ops when no progress was shown
- `IndexProgressReporter` resolves target from file metadata

Related to #89